### PR TITLE
Replacing short branch statements by equivalant non-short versions. G…

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>3</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <BuildVersion>4</BuildVersion>
+    <BuildVersion>5</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Builder/ProxyGeneratorBuilder.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Builder/ProxyGeneratorBuilder.cs
@@ -391,12 +391,12 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Builder
             // if (interfaceId == <interfaceId>)
             ilGen.Emit(OpCodes.Ldarg_1);
             ilGen.Emit(OpCodes.Ldc_I4, interfaceId);
-            ilGen.Emit(OpCodes.Bne_Un_S, elseLabel);
+            ilGen.Emit(OpCodes.Bne_Un, elseLabel);
 
             // if (methodId == <methodId>)
             ilGen.Emit(OpCodes.Ldarg_2);
             ilGen.Emit(OpCodes.Ldc_I4, methodId);
-            ilGen.Emit(OpCodes.Bne_Un_S, elseLabel);
+            ilGen.Emit(OpCodes.Bne_Un, elseLabel);
 
             var castedResponseBody = ilGen.DeclareLocal(responseBodyType);
             ilGen.Emit(OpCodes.Ldarg_3); // load responseBody object

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/Builder/MethodDispatcherBuilder.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/Builder/MethodDispatcherBuilder.cs
@@ -217,7 +217,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Builder
 
             // 2 If true then call GetValue
             AddIfWrapMsgGetParameters(ilGen, castedObject, methodBodyTypes);
-            ilGen.Emit(OpCodes.Br_S, endlabel);
+            ilGen.Emit(OpCodes.Br, endlabel);
             ilGen.MarkLabel(elseLabelforWrapped);
 
             // else call GetParameter on IServiceRemotingMessageBody
@@ -299,7 +299,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Builder
 
             // 2 If true then call GetValue
             AddIfWrapMsgGetParameters(ilGen, castedObject, methodBodyTypes);
-            ilGen.Emit(OpCodes.Br_S, endlabel);
+            ilGen.Emit(OpCodes.Br, endlabel);
             ilGen.MarkLabel(elseLabelforWrapped);
 
             // else call GetParameter on IServiceRemotingMessageBody
@@ -350,7 +350,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Builder
             ilGen.Emit(OpCodes.Call, this.checkIfitsWrapped);
             ilGen.Emit(OpCodes.Stloc, boolres);
             ilGen.Emit(OpCodes.Ldloc, boolres);
-            ilGen.Emit(OpCodes.Brfalse_S, elseLabelforWrapped);
+            ilGen.Emit(OpCodes.Brfalse, elseLabelforWrapped);
         }
 
         private void AddCreateResponseBodyMethod(
@@ -400,7 +400,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Builder
             // if (methodId == <methodid>)
             ilGen.Emit(OpCodes.Ldarg_1);
             ilGen.Emit(OpCodes.Ldc_I4, methodId);
-            ilGen.Emit(OpCodes.Bne_Un_S, elseLabel);
+            ilGen.Emit(OpCodes.Bne_Un, elseLabel);
 
             var ctorInfo = responseType.GetConstructor(Type.EmptyTypes);
             if (ctorInfo != null)

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/Builder/ProxyGeneratorBuilder.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/Builder/ProxyGeneratorBuilder.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Builder
             ilGen.Emit(OpCodes.Stloc, boolres2);
             ilGen.Emit(OpCodes.Ldloc_3, boolres2);
             var elseLabel = ilGen.DefineLabel();
-            ilGen.Emit(OpCodes.Brfalse_S, elseLabel);
+            ilGen.Emit(OpCodes.Brfalse, elseLabel);
 
             // if false ,Call SetParamater
             var setMethod = typeof(IServiceRemotingRequestMessageBody).GetMethod("SetParameter");
@@ -377,12 +377,12 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Builder
             // if (interfaceId == <interfaceId>)
             ilGen.Emit(OpCodes.Ldarg_1);
             ilGen.Emit(OpCodes.Ldc_I4, interfaceId);
-            ilGen.Emit(OpCodes.Bne_Un_S, elseLabel);
+            ilGen.Emit(OpCodes.Bne_Un, elseLabel);
 
             // if (methodId == <methodId>)
             ilGen.Emit(OpCodes.Ldarg_2);
             ilGen.Emit(OpCodes.Ldc_I4, methodId);
-            ilGen.Emit(OpCodes.Bne_Un_S, elseLabel);
+            ilGen.Emit(OpCodes.Bne_Un, elseLabel);
 
             var castedResponseBody = ilGen.DeclareLocal(responseBodyType);
             ilGen.Emit(OpCodes.Ldarg_3); // load responseBody object


### PR DESCRIPTION
Replacing short branch statements by equivalent non-short alternative. Given that the code is getting generated dynamically, target of branch operation may fall beyond 127 bytes, in which case short version of branch will fail leading to exception.