### PR TITLE
Fixed ActorStateProviderSerializer to use ActorDataContractSurrogate for DotNetCoreClr

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateProviderSerializer.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateProviderSerializer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         {
             var serializer = this.actorStateSerializerCache.GetOrAdd(
                 stateType,
-                CreateDataContractSerializer);
+                ActorStateProviderHelper.CreateDataContractSerializer);
 
             using (var stream = new MemoryStream())
             {
@@ -47,7 +47,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
             var serializer = this.actorStateSerializerCache.GetOrAdd(
                 typeof(T),
-                CreateDataContractSerializer);
+                ActorStateProviderHelper.CreateDataContractSerializer);
 
             using (var stream = new MemoryStream(buffer))
             {
@@ -56,20 +56,6 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                     return (T)serializer.ReadObject(reader);
                 }
             }
-        }
-
-        private static DataContractSerializer CreateDataContractSerializer(Type actorStateType)
-        {
-            return new DataContractSerializer(
-                actorStateType,
-                new DataContractSerializerSettings
-                {
-                    MaxItemsInObjectGraph = int.MaxValue,
-#if !DotNetCoreClr
-                    DataContractSurrogate = ActorDataContractSurrogate.Instance,
-#endif
-                    KnownTypes = new[] { typeof(ActorReference) },
-                });
         }
     }
 }


### PR DESCRIPTION
ActorStateProviderSerializer was not using ActorDataContractSurrogate in DotNetCoreClr. This prevents serialization of actor proxies to state. Modified ActorStateProviderSerializer  to use the existing (and currently unreferenced) ActorStateProviderHelper.CreateDataContractSerializer static method, which handles ActorDataContractSurrogate correctly for DotNetCoreClr.

Related to the fix for https://github.com/Azure/service-fabric-issues/issues/590