### PR TITLE
Making Dispose Method virtual

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>3</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <BuildVersion>9</BuildVersion>
+    <BuildVersion>10</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Services/Communication/Client/CommunicationClientFactoryBase.cs
+++ b/src/Microsoft.ServiceFabric.Services/Communication/Client/CommunicationClientFactoryBase.cs
@@ -281,7 +281,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Client
         /// Dispose the managed/unmanaged resouces.
         /// Dispose Method is being added rather than making it IDisposable so that it doesn't change type information and wont be a breaking change.
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             ServiceTrace.Source.WriteInfo(
                                TraceType,


### PR DESCRIPTION
For the cases where user ClientFactory implementation is implementing IDisposable, they can now extend the Dispose implementation by overriding it.