### PR TITLE
RegisterReminderAsync DueTime validation

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminder.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminder.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         private void ValidateDueTime(string argName, TimeSpan value)
         {
-            if (value < TimeSpan.Zero)
+            if (value < this.minTimePeriod)
             {
                 throw new ArgumentOutOfRangeException(
                     argName,


### PR DESCRIPTION
The RegisterReminderAsync method should accept "negative one (-1) milliseconds" as a valid value of its dueTime parameter. This is both specified in the the [documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicefabric.actors.runtime.actorbase.registerreminderasync?view=azure-dotnet) and in the message of an exception thrown when this validation fails (TimeSpan TotalMilliseconds specified value must be between -1 and 922337203685477, Parameter name: DueTime). Other code which uses the DueTime property seems to be aware of -1 value and handles it correctly.