### PR TITLE
Releasing the lock after request waiting on a delay

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>3</MajorVersion>
     <MinorVersion>3</MinorVersion>
-    <BuildVersion>12</BuildVersion>
+    <BuildVersion>13</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Services/Communication/Client/ExponentialRetryPolicy.cs
+++ b/src/Microsoft.ServiceFabric.Services/Communication/Client/ExponentialRetryPolicy.cs
@@ -67,7 +67,16 @@ namespace Microsoft.ServiceFabric.Services.Communication.Client
         /// <inheritdoc/>
         public TimeSpan GetNextRetryDelay(RetryDelayParameters retryDelayParameters)
         {
-          return TimeSpan.FromSeconds((this.maxRetryJitter.TotalSeconds * RandomGenerator.NextDouble()) + (1 << retryDelayParameters.RetryAttempt));
+            // This we are doing to increase delay gradually . For every 3 consecutive retrries, delay wuld be same.
+            int delayMultiplier = retryDelayParameters.RetryAttempt / 3;
+
+            // Capping the Max Retry Time to nearest 5 mins ~ Pow(2,9)
+            if (delayMultiplier >= 9)
+            {
+                delayMultiplier = 9;
+            }
+
+            return TimeSpan.FromSeconds((this.maxRetryJitter.TotalSeconds * RandomGenerator.NextDouble()) + (1 << delayMultiplier));
         }
     }
 }


### PR DESCRIPTION
Changes

Releasing the lock after request waiting on a delay.
Disposing CancellationTokenSource after task finished. This is for the case if customer is using ClientRetryTimeoutSetting.
Creating Internal ServiceProxyFactory under lock.
Capping The Exponential Delay to 5 mins.
Increasing the Exponential  delay gradually .
