### PR TITLE
Resolve issue #198 - WCF Host fails to apply transaction configuration of WCF configuration for service

### DIFF
--- a/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/Runtime/WcfAsyncThreadExceptionHandler.cs
+++ b/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/Runtime/WcfAsyncThreadExceptionHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf.Runtime
         {
             ServiceTrace.Source.WriteWarning(
                 this.traceType,
-                "Excepion {0}  Stacktrace {1} occured in Wcf Service Background Threads",
+                "Exception {0}  Stacktrace {1} occured in Wcf Service Background Threads",
                 exception.Message,
                 exception.StackTrace);
 

--- a/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/Runtime/WcfCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/Runtime/WcfCommunicationListener.cs
@@ -196,7 +196,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf.Runtime
                 this.publishAddress = serviceContext.PublishAddress;
             }
 
-            this.endpoint = CreateServiceEndpoint(typeof(TServiceContract), listenerBinding, address);
+            this.endpoint = CreateServiceEndpoint(typeof(TServiceContract), wcfServiceObject, listenerBinding, address);
             this.host = CreateServiceHost(wcfServiceObject, this.endpoint);
         }
 
@@ -220,7 +220,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf.Runtime
                     endpointResourceName);
             }
 
-            this.endpoint = CreateServiceEndpoint(typeof(TServiceContract), listenerBinding, address);
+            this.endpoint = CreateServiceEndpoint(typeof(TServiceContract), wcfServiceType, listenerBinding, address);
             this.host = CreateServiceHost(wcfServiceType, this.endpoint);
         }
 
@@ -300,10 +300,21 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf.Runtime
             this.host.Abort();
         }
 
-        private static ServiceEndpoint CreateServiceEndpoint(Type contractType, Binding binding, EndpointAddress address)
+        private static ServiceEndpoint CreateServiceEndpoint(Type contractType, Type serviceType, Binding binding, EndpointAddress address)
         {
             var endpoint = new ServiceEndpoint(
-                ContractDescription.GetContract(contractType),
+                ContractDescription.GetContract(contractType, serviceType),
+                binding,
+                address);
+            endpoint.Behaviors.Add(new ListenUriEndpointBehavior());
+
+            return endpoint;
+        }
+
+        private static ServiceEndpoint CreateServiceEndpoint(Type contractType, object serviceImplementation, Binding binding, EndpointAddress address)
+        {
+            var endpoint = new ServiceEndpoint(
+                ContractDescription.GetContract(contractType, serviceImplementation),
                 binding,
                 address);
             endpoint.Behaviors.Add(new ListenUriEndpointBehavior());


### PR DESCRIPTION
PR to resolve #198 & #67 

Code change passes service implementation instance (or type depending on constructor used) down the call chain where it is used to create service endpoint instances which in turn is used by service host to configure and activate WCF service.

Local test confirms fix with WCF Service Host within Service Fabric applies configuration declared by `[ServiceBehavior(...)]` attribute, like implicit transaction scope.