### PR TITLE
Fixed NullReferenceException in CreateServiceInstanceListeners

### DIFF
--- a/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -309,7 +309,17 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
             foreach (var entry in this.instanceListeners)
             {
+                string traceMsg;
+
                 var communicationListener = entry.CreateCommunicationListener(this.serviceContext);
+                if (communicationListener is null)
+                {
+                    traceMsg = $"Skipped '{entry.Name}' (<null>) communication listener.";
+                    ServiceTrace.Source.WriteInfoWithId(TraceType, this.traceId, traceMsg);
+
+                    continue;
+                }
+
                 var communicationListenerInfo = new CommunicationListenerInfo
                 {
                     Name = entry.Name.Equals(ServiceInstanceListener.DefaultName) ? "default" : entry.Name,
@@ -318,7 +328,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 this.AddCommunicationListener(communicationListenerInfo);
 
-                var traceMsg = $"Opening {communicationListenerInfo.Name} communication listener.";
+                traceMsg = $"Opening {communicationListenerInfo.Name} communication listener.";
                 ServiceTrace.Source.WriteInfoWithId(TraceType, this.traceId, traceMsg);
 
                 var endpointAddress = await communicationListener.OpenAsync(cancellationToken);

--- a/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -311,6 +311,13 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             {
                 string traceMsg;
 
+                if (entry is null)
+                {
+                    traceMsg = $"Skipped (<null>) instance listener.";
+                    ServiceTrace.Source.WriteInfoWithId(TraceType, this.traceId, traceMsg);
+                    continue;
+                }
+
                 var communicationListener = entry.CreateCommunicationListener(this.serviceContext);
                 if (communicationListener is null)
                 {

--- a/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -313,7 +313,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
 
                 if (entry is null)
                 {
-                    traceMsg = $"Skipped (<null>) instance listener.";
+                    traceMsg = "Skipped (<null>) instance listener.";
                     ServiceTrace.Source.WriteInfoWithId(TraceType, this.traceId, traceMsg);
                     continue;
                 }


### PR DESCRIPTION
## Summary

I have implemented additional `null` checks in `StatelessServiceInstanceAdapter` related to opening communication listeners. 

These changes are targeted to prevent `NullReferenceException` and allow implementations of `StatelessService` to simplify conditions implementation when creating communication listeners in `CreateServiceInstanceListeners` method by returning both `null` instances of `ServiceInstanceListener` and `ICommunicationListener`.

## Motivation

Currently I am working on a project with Reliable Services and I have found two interesting moments related to `CreateServiceInstanceListeners`method.

### Case 1

Currently if you return `new ServiceInstanceListener[] { null }` then Service Fabric will throw `NullReferenceException`. 

This case was discovered when I was modifying a logic of one of the services:

_This code is an illustration_
```
protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
{
  return new ServiceInstanceListener[]
  {
    this.CreateUserInstanceListener(),
    this.CreateAdminInstanceListener()
  };
}
```

The issue happened when logic of `CreateUserInstanceListener` was modified to read configuration and return `null` when user listener should be exposed. 

I completely understand that this situation can be managed by code similar to this:

```
protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
{
  var listeners = new List<ServiceInstanceListener>(2);
  var userListener = this.CreateUserInstanceListener();
  if (!object.ReferenceEquals(userListener, null)) {
    listeners.Add(userListener);
  }
  ...
  
  return listeners;
}
```

But this adds additional overhead. That is why in this PR I have added small logic to report this situation to `Trace` and continue execution.

### Case 2

This case is very similar to previous one. The thing here is that `ServiceInstanceListener` accepts `Func<StatelessServiceContext, ICommunicationListener>`. Inside this function there are cases when you need to analyze information from `StatelessServiceContext` and make decision whether to create `ICommunicationListener` or not. Currently you cannot return `null` from this function because it will cause `NullReferenceException`.

Like in the previous case this one also can be solved in advance by using `this.Context` property but at the same time as in the previous case this would introduce additional overhead.

That is why in this PR I have added small logic to report this situation to Trace and continue execution.

## Conclusion

I am not sure whether this kind of changes are acceptable because they could contradict with the way how this kind of situations are addressed in this project. That is why if this kind of changes aren't aligned with the project feel free to close the PR.