### PR TITLE
Fix System.DivideByZeroException in PerformanceCounterInstanceNameBuilder.ComputeTruncatedMethodName for overloaded service methods

### DIFF
--- a/src/Microsoft.ServiceFabric.Services.Remoting/Diagnostic/PerformanceCounterInstanceNameBuilder.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Diagnostic/PerformanceCounterInstanceNameBuilder.cs
@@ -221,7 +221,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Diagnostic
             var partsToTruncate = new List<MethodNameParts>();
 
             // Check if we should truncate the type component of the method name
-            var typeFull = methodNameBuilder.MethodInfo.DeclaringType.Name;
+            var typeFull = methodNameBuilder.MethodInfo.DeclaringType.FullName;
             this.PrepareMethodNamePartForTruncation(
                 typeFull,
                 MethodNameParts.DeclaringType,


### PR DESCRIPTION
See issue: https://github.com/microsoft/service-fabric-services-and-actors-dotnet/issues/234
Multiple IService implementations causing 'System.DivideByZeroException' in ServiceRemotingMessageDispatcher
