### PR TITLE
dispose actor reminder in case of update

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
@@ -1254,7 +1254,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 actorReminder,
                 (k, v) =>
                 {
-                    v.CancelTimer();
+                    v.Dispose();
                     return actorReminder;
                 });
 


### PR DESCRIPTION
I encounter issue in our project we are updating existing reminder by calling RegisterReminderAsync and it works well. The issue we notice is memory usage increase after investigating we saw that the RC was ActorReminders waiting in the finilizer queue.
Reviewing the code I saw that on update reminder we create new reminder and just call CancelTimer on the "old" one. I suggest that on update we can just Dispose the "old" reminder which will suppress finalizers.
