### PR TITLE
Fix: StatelessServiceInstanceAdapter to solve onOpenAsync bug

### DIFF
--- a/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/StatelessServiceInstanceAdapter.cs
@@ -96,26 +96,19 @@ namespace Microsoft.ServiceFabric.Services.Runtime
             this.runAsynCancellationTokenSource = new CancellationTokenSource();
             this.executeRunAsyncTask = this.ScheduleRunAsync(this.runAsynCancellationTokenSource.Token);
 
-            Exception onOpenAsyncEx = null;
-
             try
             {
                 await this.userServiceInstance.OnOpenAsync(cancellationToken);
             }
             catch (Exception exception)
             {
-                onOpenAsyncEx = exception;
                 ServiceTrace.Source.WriteWarningWithId(
                     TraceType,
                     this.traceId,
                     "Got exception when calling onOpenAsync",
                     exception);
-            }
-
-            if (onOpenAsyncEx != null)
-            {
                 await this.CloseCommunicationListenersAsync(cancellationToken);
-                throw onOpenAsyncEx;
+                throw exception;
             }
 
             return this.endpointCollection.ToString();


### PR DESCRIPTION
Communication Listeners were not getting closed when exception was being thrown from users implementation of onOpenAsync. Fix closes the listeners gracefully.

Fix for [Bug-1057](https://github.com/microsoft/service-fabric/issues/1057)