### PR TITLE
Check if runtimeconfig.dev.json exists

### DIFF
--- a/src/netstandard/FabActUtil/Microsoft.ServiceFabric.Actors.targets
+++ b/src/netstandard/FabActUtil/Microsoft.ServiceFabric.Actors.targets
@@ -16,7 +16,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ActorServiceAssemblies Include="$(TargetDir)\*" />
       <FabActUtilAssemblies Include="$(MSBuildThisFileDirectory)\*" />
     </ItemGroup>
-    <Copy SourceFiles="$(TargetDir)\$(AssemblyName).runtimeconfig.dev.json" DestinationFiles="$(FabActUtilWorkingDir)\FabActUtil.runtimeconfig.dev.json" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetDir)\$(AssemblyName).runtimeconfig.dev.json" DestinationFiles="$(FabActUtilWorkingDir)\FabActUtil.runtimeconfig.dev.json" SkipUnchangedFiles="true" Condition="Exists('$(TargetDir)\$(AssemblyName).runtimeconfig.dev.json')" />
     <Copy SourceFiles="$(TargetDir)\$(AssemblyName).deps.json" DestinationFiles="$(FabActUtilWorkingDir)\FabActUtil.deps.json" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(ActorServiceAssemblies)" DestinationFolder="$(FabActUtilWorkingDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(FabActUtilAssemblies)" DestinationFolder="$(FabActUtilWorkingDir)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
.NET 6 doesn't create runtimeconfig.dev.json by default  See:  https://github.com/dotnet/sdk/issues/16818
This crashes the build of Service fabric projects that use .NET 6 services/actors.
I've created the issues at : https://github.com/microsoft/service-fabric/issues/1289 