### PR TITLE
Modifying actor enumeration for KVS

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateProviderHelper.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateProviderHelper.cs
@@ -496,102 +496,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             return Task.FromResult(actorQueryResult);
         }
 
-        internal Task<PagedResult<ActorId>> GetStoredActorIdsForKvsAsync(
-            int itemsCount,
-            ContinuationToken continuationToken,
-            KeyValueStoreReplica replica,
-            CancellationToken cancellationToken)
-        {
-            var actorIdList = new List<ActorId>();
-            var actorQueryResult = new PagedResult<ActorId>();
-
-            IEnumerator<KeyValueStoreItem> enumerator;
-            bool enumHasMoreEntries;
-            using var txn = replica.CreateTransaction();
-
-            // Find continuation point for enumeration
-            if (continuationToken != null)
-            {
-                long previousActorCount = 0L;
-                if (long.TryParse((string)continuationToken.Marker, out previousActorCount))
-                {
-                    enumerator = replica.Enumerate(txn, ActorStateProviderHelper.ActorPresenceStorageKeyPrefix, true);
-                    enumHasMoreEntries = this.GetContinuationPointByActorCount(previousActorCount, enumerator, cancellationToken);
-                }
-                else
-                {
-                    string lastSeenActorStorageKey = continuationToken.Marker.ToString();
-                    enumerator = replica.Enumerate(txn, lastSeenActorStorageKey, false);
-                    enumHasMoreEntries = enumerator.MoveNext();
-                    if (enumHasMoreEntries)
-                    {
-                        enumHasMoreEntries = enumerator.MoveNext();
-                    }
-                }
-
-                if (!enumHasMoreEntries)
-                {
-                    // We are here means the current snapshot that enumerator represents
-                    // has less entries that what ContinuationToken contains.
-                    return Task.FromResult(actorQueryResult);
-                }
-            }
-            else
-            {
-                enumerator = replica.Enumerate(txn, ActorStateProviderHelper.ActorPresenceStorageKeyPrefix, true);
-                enumHasMoreEntries = enumerator.MoveNext();
-            }
-
-            if (!enumHasMoreEntries)
-            {
-                return Task.FromResult(actorQueryResult);
-            }
-
-            while (enumHasMoreEntries)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var storageKey = enumerator.Current.Metadata.Key;
-                var actorId = GetActorIdFromPresenceStorageKey(storageKey);
-
-                if (actorId != null)
-                {
-                    actorIdList.Add(actorId);
-                }
-                else
-                {
-                    ActorTrace.Source.WriteWarningWithId(
-                        this.owner.TraceType,
-                        this.owner.TraceId,
-                        string.Format("Failed to parse ActorId from storage key: {0}", storageKey));
-                }
-
-                enumHasMoreEntries = enumerator.MoveNext();
-
-                if (actorIdList.Count == itemsCount)
-                {
-                    actorQueryResult.Items = actorIdList.AsReadOnly();
-
-                    // If enumerator has more elements, then set the continuation token.
-                    if (enumHasMoreEntries)
-                    {
-                        actorQueryResult.ContinuationToken = new ContinuationToken(storageKey.ToString());
-                    }
-
-                    return Task.FromResult(actorQueryResult);
-                }
-            }
-
-            // We are here means 'actorIdList' contains less than 'itemsCount'
-            // item or it is empty. The continuation token will remain null.
-            actorQueryResult.Items = actorIdList.AsReadOnly();
-
-            return Task.FromResult(actorQueryResult);
-        }
-
-        #region Private Helpers
-
-        private bool GetContinuationPointByActorCount<T>(
+        internal bool GetContinuationPointByActorCount<T>(
             long previousActorCount,
             IEnumerator<T> enumerator,
             CancellationToken cancellationToken)
@@ -610,6 +515,8 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
             return enumHasMoreEntries;
         }
+
+        #region Private Helpers
 
         private bool GetContinuationPointByActorStorageKey<T>(
             string lastSeenActorStorageKey,

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
@@ -1375,11 +1375,10 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         {
             using (var tx = this.storeReplica.CreateTransaction())
             {
-                return this.actorStateProviderHelper.GetStoredActorIdsAsync(
+                return this.actorStateProviderHelper.GetStoredActorIdsForKvsAsync(
                     itemsCount,
                     continuationToken,
-                    () => this.storeReplica.EnumerateMetadata(tx, ActorStateProviderHelper.ActorPresenceStorageKeyPrefix),
-                    metadata => metadata.Key,
+                    this.storeReplica,
                     cancellationToken);
             }
         }

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
@@ -1462,7 +1462,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                     actorQueryResult.Items = actorIdList.AsReadOnly();
 
                     // If enumerator has more elements, then set the continuation token.
-                    if (enumHasMoreEntries)
+                    if (enumHasMoreEntries && enumerator.Current.Metadata.Key.StartsWith(ActorStateProviderHelper.ActorPresenceStorageKeyPrefix))
                     {
                         actorQueryResult.ContinuationToken = new ContinuationToken(storageKey.ToString());
                     }

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
@@ -1375,12 +1375,107 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         {
             using (var tx = this.storeReplica.CreateTransaction())
             {
-                return this.actorStateProviderHelper.GetStoredActorIdsForKvsAsync(
+                return this.GetStoredActorIdsForKvsAsync(
                     itemsCount,
                     continuationToken,
                     this.storeReplica,
                     cancellationToken);
             }
+        }
+
+        private Task<PagedResult<ActorId>> GetStoredActorIdsForKvsAsync(
+            int itemsCount,
+            ContinuationToken continuationToken,
+            KeyValueStoreReplica replica,
+            CancellationToken cancellationToken)
+        {
+            var actorIdList = new List<ActorId>();
+            var actorQueryResult = new PagedResult<ActorId>();
+
+            IEnumerator<KeyValueStoreItem> enumerator;
+            bool enumHasMoreEntries;
+            using var txn = replica.CreateTransaction();
+
+            // Find continuation point for enumeration
+            if (continuationToken != null)
+            {
+                long previousActorCount = 0L;
+                if (long.TryParse((string)continuationToken.Marker, out previousActorCount))
+                {
+                    enumerator = replica.Enumerate(txn, ActorStateProviderHelper.ActorPresenceStorageKeyPrefix, true);
+                    enumHasMoreEntries = this.actorStateProviderHelper.GetContinuationPointByActorCount(previousActorCount, enumerator, cancellationToken);
+                    enumHasMoreEntries = enumerator.MoveNext();
+                }
+                else
+                {
+                    string lastSeenActorStorageKey = continuationToken.Marker.ToString();
+                    enumerator = replica.Enumerate(txn, lastSeenActorStorageKey, false);
+                    enumHasMoreEntries = enumerator.MoveNext();
+                    var storageKey = enumerator.Current.Metadata.Key;
+                    if (enumHasMoreEntries && storageKey == lastSeenActorStorageKey)
+                    {
+                        enumHasMoreEntries = enumerator.MoveNext();
+                    }
+                }
+
+                if (!enumHasMoreEntries)
+                {
+                    // We are here means the current snapshot that enumerator represents
+                    // has less entries that what ContinuationToken contains.
+                    return Task.FromResult(actorQueryResult);
+                }
+            }
+            else
+            {
+                enumerator = replica.Enumerate(txn, ActorStateProviderHelper.ActorPresenceStorageKeyPrefix, true);
+                enumHasMoreEntries = enumerator.MoveNext();
+            }
+
+            if (!enumHasMoreEntries)
+            {
+                return Task.FromResult(actorQueryResult);
+            }
+
+            while (enumHasMoreEntries && enumerator.Current.Metadata.Key.StartsWith(ActorStateProviderHelper.ActorPresenceStorageKeyPrefix))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var storageKey = enumerator.Current.Metadata.Key;
+                var actorId = ActorStateProviderHelper.GetActorIdFromPresenceStorageKey(storageKey);
+
+                if (actorId != null)
+                {
+                    actorIdList.Add(actorId);
+                }
+                else
+                {
+                    ActorTrace.Source.WriteWarningWithId(
+                        TraceType,
+                        this.traceId,
+                        string.Format("Failed to parse ActorId from storage key: {0}", storageKey));
+                }
+
+                enumHasMoreEntries = enumerator.MoveNext();
+
+                if (actorIdList.Count == itemsCount)
+                {
+                    actorQueryResult.Items = actorIdList.AsReadOnly();
+
+                    // If enumerator has more elements, then set the continuation token.
+                    if (enumHasMoreEntries)
+                    {
+                        actorQueryResult.ContinuationToken = new ContinuationToken(storageKey.ToString());
+                    }
+
+                    return Task.FromResult(actorQueryResult);
+                }
+            }
+
+            // We are here means 'actorIdList' contains less than 'itemsCount'
+            // item or it is empty. The continuation token will remain null.
+            actorQueryResult.Items = actorIdList.AsReadOnly();
+
+            return Task.FromResult(actorQueryResult);
         }
 
         private class ReminderKeyInfo


### PR DESCRIPTION
Modifying actor enumeration for KVS to take into account the different ordering for actors between KVS and RC.
Tested locally with 5L actors 