### PR TITLE
Manual mode migration bug fix

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationConstants.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationConstants.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
         internal static readonly string GetKVSValueByKeys = "GetValueByKeys";
 
         internal static readonly string RejectWritesKey = "_RejectWrites_";
-        internal static readonly string IsDowntimeAllowed = "_IsDowntimeAllowed_";
+        internal static readonly string IsDowntimeInvoked = "_IsDowntimeInvoked_";
 
         #region Global Migration constants
         internal static readonly string MigrationStartDateTimeUTC = "_MigrationStartDateTimeUTC_";

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationConstants.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationConstants.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
         internal static readonly string GetKVSValueByKeys = "GetValueByKeys";
 
         internal static readonly string RejectWritesKey = "_RejectWrites_";
+        internal static readonly string IsDowntimeAllowed = "_IsDowntimeAllowed_";
 
         #region Global Migration constants
         internal static readonly string MigrationStartDateTimeUTC = "_MigrationStartDateTimeUTC_";

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationUtility.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/MigrationUtility.cs
@@ -114,6 +114,22 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
             return value;
         }
 
+        public static async Task<bool> ParseBoolAsync(Func<Task<string>> func, string traceId)
+        {
+            string valueString = await func();
+            if (string.IsNullOrEmpty(valueString))
+            {
+                return false;
+            }
+
+            if (!bool.TryParse(valueString, out var value))
+            {
+                TraceAndThrowException(valueString, traceId);
+            }
+
+            return value;
+        }
+
         private static void TraceAndThrowException<TData>(TData data, string traceId)
         {
             ActorTrace.Source.WriteErrorWithId(

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/TargetMigrationOrchestrator.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/TargetMigrationOrchestrator.cs
@@ -604,10 +604,9 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
             {
                 if (!this.IsAutoStartMigration())
                 {
-                    var tx = this.migrationActorStateProvider.GetStateManager().CreateTransaction();
                     var isDowntimeInvoked = (await ParseBoolAsync(
                         () => this.MetaDataDictionary.GetValueOrDefaultAsync(
-                            tx,
+                            this.Transaction,
                             Key(IsDowntimeAllowed),
                             DefaultRCTimeout,
                             cancellationToken),


### PR DESCRIPTION
Bug description:
For manual mode migration, if a failover happens during downtime phase, while resuming migration catchup iterations are resumed since the flag _isDowntimeAllowed = true_ is stored in-memory and lost during the failover

Fix:
_isDowntimeAllowed_ is stored in metadata dict and its value is checked if phase==catchup while resuming migration after a failover.