### PR TITLE
Update ServiceInterfaceDescription to use correct error message when the interface isn't IService

### DIFF
--- a/src/Microsoft.ServiceFabric.Services.Remoting/Description/ServiceInterfaceDescription.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Description/ServiceInterfaceDescription.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Description
                     throw new ArgumentException(
                        string.Format(
                            CultureInfo.CurrentCulture,
-                           SR.ErrorNotAServiceInterface_DerivationCheck1,
+                           SR.ErrorNotAServiceInterface_DerivationCheck2,
                            serviceInterfaceType.FullName,
                            nonActorParentInterface.FullName,
                            typeof(IService).FullName),


### PR DESCRIPTION
The PR fixes a trivial bug when an incorrect error message was picked up from the resources.