### PR TITLE
Updated remoting listener extensions to support exception serialization

### DIFF
--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -145,7 +145,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
             where TStatelessService : StatelessService, IService
         {
             return CreateServiceRemotingInstanceListeners(
-                serviceImplementation, Array.Empty<V2.Runtime.IExceptionConvertor>());
+                serviceImplementation, Enumerable.Empty<V2.Runtime.IExceptionConvertor>().ToArray());
         }
 
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
-
 namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
 {
     using System;
@@ -72,18 +70,19 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
         /// derive from <see cref="Microsoft.ServiceFabric.Services.Runtime.StatefulServiceBase"/> and implement one or more
         /// interfaces that derive from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</typeparam>
         /// <param name="serviceImplementation">A stateful service implementation.</param>
+        /// <param name="serializationTechnique">The exception serialization technique to use. Defaults to BinaryFormatter.</param>
         /// <returns>A <see cref="IServiceRemotingListener"/> communication
         /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
         public static IEnumerable<ServiceReplicaListener> CreateServiceRemotingReplicaListeners<TStatefulService>(
-            this TStatefulService serviceImplementation)
+            this TStatefulService serviceImplementation, FabricTransportRemotingListenerSettings.ExceptionSerialization serializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.BinaryFormatter)
             where TStatefulService : StatefulServiceBase, IService
         {
             return CreateServiceRemotingReplicaListeners(
-                serviceImplementation, Enumerable.Empty<V2.Runtime.IExceptionConvertor>().ToArray());
+                serviceImplementation, Enumerable.Empty<V2.Runtime.IExceptionConvertor>().ToArray(), serializationTechnique);
         }
 
         /// <summary>
-        ///  An extension method that creates an <see cref="IServiceRemotingListener"/>
+        /// An extension method that creates an <see cref="IServiceRemotingListener"/>
         /// for a stateful service implementation.
         /// </summary>
         /// <typeparam name="TStatefulService">Type constraint on the service implementation. The service implementation must
@@ -95,6 +94,26 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
         /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
         public static IEnumerable<ServiceReplicaListener> CreateServiceRemotingReplicaListeners<TStatefulService>(
             this TStatefulService serviceImplementation, V2.Runtime.IExceptionConvertor[] exceptionConvertors)
+            where TStatefulService : StatefulServiceBase, IService
+        {
+            return CreateServiceRemotingReplicaListeners(
+                serviceImplementation, exceptionConvertors, FabricTransportRemotingListenerSettings.ExceptionSerialization.Default);
+        }
+
+        /// <summary>
+        ///  An extension method that creates an <see cref="IServiceRemotingListener"/>
+        /// for a stateful service implementation.
+        /// </summary>
+        /// <typeparam name="TStatefulService">Type constraint on the service implementation. The service implementation must
+        /// derive from <see cref="Microsoft.ServiceFabric.Services.Runtime.StatefulServiceBase"/> and implement one or more
+        /// interfaces that derive from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</typeparam>
+        /// <param name="serviceImplementation">A stateful service implementation.</param>
+        /// <param name="exceptionConvertors">An array of <see cref="V2.Runtime.IExceptionConvertor"/> to use in serializing and deserializing exceptions.</param>
+        /// <param name="serializationTechnique">The exception serialization technique to use.</param>
+        /// <returns>A <see cref="IServiceRemotingListener"/> communication
+        /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
+        internal static IEnumerable<ServiceReplicaListener> CreateServiceRemotingReplicaListeners<TStatefulService>(
+            this TStatefulService serviceImplementation, V2.Runtime.IExceptionConvertor[] exceptionConvertors, FabricTransportRemotingListenerSettings.ExceptionSerialization serializationTechnique)
             where TStatefulService : StatefulServiceBase, IService
         {
             var serviceTypeInformation = ServiceTypeInformation.Get(serviceImplementation.GetType());
@@ -121,7 +140,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
                         impl,
                         new FabricTransportRemotingListenerSettings
                         {
-                            ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default,
+                            ExceptionSerializationTechnique = serializationTechnique,
                             UseWrappedMessage = true,
                         },
                         exceptionConvertors: exceptionConvertors);
@@ -142,14 +161,18 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
         /// derive from <see cref="System.Fabric.Query.StatelessService"/> and implement one or more
         /// interfaces that derive from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</typeparam>
         /// <param name="serviceImplementation">A stateless service implementation.</param>
+        /// <param name="serializationTechnique">The exception serialization technique. Defaults to BinaryFormatter.</param>
         /// <returns>A <see cref="IServiceRemotingListener"/> communication
         /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
+#pragma warning disable SA1202
         public static IEnumerable<ServiceInstanceListener> CreateServiceRemotingInstanceListeners<TStatelessService>(
-            this TStatelessService serviceImplementation)
+            this TStatelessService serviceImplementation,
+            FabricTransportRemotingListenerSettings.ExceptionSerialization serializationTechnique =
+                FabricTransportRemotingListenerSettings.ExceptionSerialization.BinaryFormatter)
             where TStatelessService : StatelessService, IService
         {
             return CreateServiceRemotingInstanceListeners(
-                serviceImplementation, Enumerable.Empty<V2.Runtime.IExceptionConvertor>().ToArray());
+                serviceImplementation, Enumerable.Empty<V2.Runtime.IExceptionConvertor>().ToArray(), serializationTechnique);
         }
 
         /// <summary>
@@ -165,6 +188,27 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
         /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
         public static IEnumerable<ServiceInstanceListener> CreateServiceRemotingInstanceListeners<TStatelessService>(
             this TStatelessService serviceImplementation, V2.Runtime.IExceptionConvertor[] exceptionConvertors)
+            where TStatelessService : StatelessService, IService
+        {
+            return CreateServiceRemotingInstanceListeners(
+                serviceImplementation, exceptionConvertors, FabricTransportRemotingListenerSettings.ExceptionSerialization.Default);
+        }
+#pragma warning restore SA1202
+
+        /// <summary>
+        /// An extension method that creates an <see cref="IServiceRemotingListener"/>
+        /// for a stateless service implementation.
+        /// </summary>
+        /// <typeparam name="TStatelessService">Type constraint on the service implementation. The service implementation must
+        /// derive from <see cref="System.Fabric.Query.StatelessService"/> and implement one or more
+        /// interfaces that derive from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</typeparam>
+        /// <param name="serviceImplementation">A stateless service implementation.</param>
+        /// <param name="exceptionConvertors">An array of <see cref="V2.Runtime.IExceptionConvertor"/> to use in serializing and deserializing exceptions.</param>
+        /// <param name="exceptionSerialization">The exception serialization technique to use.</param>
+        /// <returns>A <see cref="IServiceRemotingListener"/> communication
+        /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
+        internal static IEnumerable<ServiceInstanceListener> CreateServiceRemotingInstanceListeners<TStatelessService>(
+            this TStatelessService serviceImplementation, V2.Runtime.IExceptionConvertor[] exceptionConvertors, FabricTransportRemotingListenerSettings.ExceptionSerialization exceptionSerialization)
             where TStatelessService : StatelessService, IService
         {
             var serviceTypeInformation = ServiceTypeInformation.Get(serviceImplementation.GetType());
@@ -192,8 +236,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
                         impl,
                         new FabricTransportRemotingListenerSettings
                         {
-                            ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings
-                                .ExceptionSerialization.Default,
+                            ExceptionSerializationTechnique = exceptionSerialization,
                             UseWrappedMessage = true,
                         },
                         exceptionConvertors: exceptionConvertors);

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -132,17 +132,17 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
 #endif
             if (Helper.IsEitherRemotingV2(provider.RemotingListenerVersion))
             {
+                var listenerSettings = FabricTransportRemotingListenerSettings.GetDefault();
+                listenerSettings.ExceptionSerializationTechnique = serializationTechnique;
+                listenerSettings.UseWrappedMessage = true;
+
                 var listeners = provider.CreateServiceRemotingListeners();
                 foreach (var kvp in listeners)
                 {
                     var listener = new FabricTransportServiceRemotingListener(
                         serviceImplementation.Context,
                         impl,
-                        new FabricTransportRemotingListenerSettings
-                        {
-                            ExceptionSerializationTechnique = serializationTechnique,
-                            UseWrappedMessage = true,
-                        },
+                        listenerSettings,
                         exceptionConvertors: exceptionConvertors);
 
                     serviceReplicaListeners.Add(new ServiceReplicaListener(
@@ -204,11 +204,11 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
         /// interfaces that derive from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</typeparam>
         /// <param name="serviceImplementation">A stateless service implementation.</param>
         /// <param name="exceptionConvertors">An array of <see cref="V2.Runtime.IExceptionConvertor"/> to use in serializing and deserializing exceptions.</param>
-        /// <param name="exceptionSerialization">The exception serialization technique to use.</param>
+        /// <param name="serializationTechnique">The exception serialization technique to use.</param>
         /// <returns>A <see cref="IServiceRemotingListener"/> communication
         /// listener that remotes the interfaces deriving from <see cref="Microsoft.ServiceFabric.Services.Remoting.IService"/> interface.</returns>
         internal static IEnumerable<ServiceInstanceListener> CreateServiceRemotingInstanceListeners<TStatelessService>(
-            this TStatelessService serviceImplementation, V2.Runtime.IExceptionConvertor[] exceptionConvertors, FabricTransportRemotingListenerSettings.ExceptionSerialization exceptionSerialization)
+            this TStatelessService serviceImplementation, V2.Runtime.IExceptionConvertor[] exceptionConvertors, FabricTransportRemotingListenerSettings.ExceptionSerialization serializationTechnique)
             where TStatelessService : StatelessService, IService
         {
             var serviceTypeInformation = ServiceTypeInformation.Get(serviceImplementation.GetType());
@@ -228,17 +228,17 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
 #endif
             if (Helper.IsEitherRemotingV2(provider.RemotingListenerVersion))
             {
+                var listenerSettings = FabricTransportRemotingListenerSettings.GetDefault();
+                listenerSettings.ExceptionSerializationTechnique = serializationTechnique;
+                listenerSettings.UseWrappedMessage = true;
+
                 var listeners = provider.CreateServiceRemotingListeners();
                 foreach (var kvp in listeners)
                 {
                     var listener = new FabricTransportServiceRemotingListener(
                         serviceImplementation.Context,
                         impl,
-                        new FabricTransportRemotingListenerSettings
-                        {
-                            ExceptionSerializationTechnique = exceptionSerialization,
-                            UseWrappedMessage = true,
-                        },
+                        listenerSettings,
                         exceptionConvertors: exceptionConvertors);
 
                     serviceInstanceListeners.Add(new ServiceInstanceListener(

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -90,18 +90,15 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
 #endif
             if (Helper.IsEitherRemotingV2(provider.RemotingListenerVersion))
             {
-                if (Helper.IsEitherRemotingV2(provider.RemotingListenerVersion))
+                var listeners = provider.CreateServiceRemotingListeners();
+                foreach (var kvp in listeners)
                 {
-                    var listeners = provider.CreateServiceRemotingListeners();
-                    foreach (var kvp in listeners)
+                    serviceReplicaListeners.Add(new ServiceReplicaListener(
+                        t =>
                     {
-                        serviceReplicaListeners.Add(new ServiceReplicaListener(
-                            t =>
-                        {
-                            return kvp.Value(serviceImplementation.Context, impl);
-                        },
-                            kvp.Key));
-                    }
+                        return kvp.Value(serviceImplementation.Context, impl);
+                    },
+                        kvp.Key));
                 }
             }
 

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -213,7 +213,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
             if (Helper.IsEitherRemotingV2(provider.RemotingListenerVersion))
             {
                 throw new NotSupportedException(
-                    "This extension method doesnt support V2Listener or CompatListener. Use CreateServiceRemotingReplicaListeners for using V2Stack ");
+                    "This extension method doesn't support V2Listener or CompatListener. Use CreateServiceRemotingReplicaListeners for using V2Stack ");
             }
 
             return provider.CreateServiceRemotingListener(serviceContext, (IService)serviceImplementation);

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -11,7 +11,8 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Runtime;
-
+    using System.Fabric;
+    
     /// <summary>
     /// This class adds extensions methods to create <see cref="IServiceRemotingListener"/>
     /// for remoting methods of the service interfaces that are derived from

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -2,17 +2,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
-
 namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
 {
     using System;
     using System.Collections.Generic;
+    using System.Fabric;
+    using System.Linq;
     using Microsoft.ServiceFabric.Services.Communication.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Runtime;
-    using System.Fabric;
-    
+
     /// <summary>
     /// This class adds extensions methods to create <see cref="IServiceRemotingListener"/>
     /// for remoting methods of the service interfaces that are derived from
@@ -76,7 +76,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
             where TStatefulService : StatefulServiceBase, IService
         {
             return CreateServiceRemotingReplicaListeners(
-                serviceImplementation, Array.Empty<V2.Runtime.IExceptionConvertor>());
+                serviceImplementation, Enumerable.Empty<V2.Runtime.IExceptionConvertor>().ToArray());
         }
 
         /// <summary>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Runtime/ServiceRemotingExtensions.cs
@@ -2,6 +2,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
+
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
+
 namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
 {
     using System;
@@ -119,6 +122,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
                         new FabricTransportRemotingListenerSettings
                         {
                             ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings.ExceptionSerialization.Default,
+                            UseWrappedMessage = true,
                         },
                         exceptionConvertors: exceptionConvertors);
 
@@ -190,6 +194,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Runtime
                         {
                             ExceptionSerializationTechnique = FabricTransportRemotingListenerSettings
                                 .ExceptionSerialization.Default,
+                            UseWrappedMessage = true,
                         },
                         exceptionConvertors: exceptionConvertors);
 


### PR DESCRIPTION
The latest guidance on [exception serialization](https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-exception-serialization), provides examples indicating how the instance and replica listeners need to be updated to accommodate the new serialization settings.

Upon reading these, I realized that I use a provided extension method to configure these listeners in my own code and that this serialization change was not yet realized, so I now offer this PR to resolve this. 

I've added an overload to each extension method (`CreateServiceRemotingInstanceListener()` and `CreateServiceRemotingReplicaListener()`) to allow the developer to pass in an array of `IExceptionConvertor` for any custom exceptions they may wish to accommodate. By default, the extension provides an empty array in order to avoid necessitating any developer change to use this additional functionality. 

In order that this might be consumed without incurring any breaking changes to remoting services, I've added an overload that matches the original signature and provides an empty array of `IExceptionConvertor` to the new overload. All V1 remoting is left untouched as this change is applicable only to V2.

Rider confirms that this code matches code standard requirements and the project builds locally as expected.  Happy to make any changes as required by your team. Thank you for the consideration!