### PR TITLE
Actor reminders related tracing improvements

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
@@ -436,6 +436,13 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
             try
             {
+                ActorTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    "Firing reminder ({0}) for actor ({1})",
+                    reminder.Name,
+                    reminder.OwnerActorId.GetStorageKey());
+
                 using (var actorScope = this.GetActor(reminder.OwnerActorId, true, false))
                 {
                     var actorBase = actorScope.Actor;
@@ -1233,12 +1240,17 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         private async Task LoadRemindersAsync(CancellationToken cancellationToken)
         {
+            ActorTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    $"Loading reminders.");
+
             var reminders = await this.StateProvider.LoadRemindersAsync(cancellationToken);
 
             ActorTrace.Source.WriteInfoWithId(
                     TraceType,
                     this.traceId,
-                    $"Loading {reminders.Count} reminders.");
+                    $"Found {reminders.Count} reminders.");
 
             if (reminders.Count > 0 && !this.actorService.ActorTypeInformation.IsRemindable)
             {
@@ -1306,7 +1318,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 TraceType,
                 this.traceId,
                 "Registering reminder for actor: ({0}), reminderName: ({1}), remainingDueTime: ({2}),  saveState {3}",
-                actorReminder.OwnerActorId,
+                actorReminder.OwnerActorId.GetStorageKey(),
                 actorReminder.Name,
                 remainingDueTime,
                 saveState);

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
@@ -230,16 +230,17 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                             async innerActor => await this.HandleDirtyStateAsync(innerActor),
                             cancellationToken);
                 }
-                catch
+                catch (Exception ex)
                 {
                     // Emit diagnostic info - failed to acquire actor lock
                     this.DiagnosticsEventManager.AcquireActorLockFailed(actor);
-                    ActorTrace.Source.WriteInfoWithId(
+                    ActorTrace.Source.WriteWarningWithId(
                         TraceType,
                         this.traceId,
-                        "Acquiring lock for actor: {0}, actor method: {1} failed",
+                        "Failed to acquire lock for actor: {0}, actor method: {1}, exception - {2}",
                         actorId,
-                        actorMethodContext.MethodName);
+                        actorMethodContext.MethodName,
+                        ex.ToString());
                     throw;
                 }
 

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorManager.cs
@@ -214,6 +214,13 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
                 // Emit diagnostic info - before acquiring actor lock
                 var lockAcquireStartTime = this.DiagnosticsEventManager.AcquireActorLockStart(actor);
+                ActorTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    "Acquiring lock for actor: {0}, actor method: {1}",
+                    actorId,
+                    actorMethodContext.MethodName);
+
                 DateTime? lockAcquireFinishTime = null;
                 try
                 {
@@ -227,6 +234,12 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 {
                     // Emit diagnostic info - failed to acquire actor lock
                     this.DiagnosticsEventManager.AcquireActorLockFailed(actor);
+                    ActorTrace.Source.WriteInfoWithId(
+                        TraceType,
+                        this.traceId,
+                        "Acquiring lock for actor: {0}, actor method: {1} failed",
+                        actorId,
+                        actorMethodContext.MethodName);
                     throw;
                 }
 
@@ -238,6 +251,13 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                     lockAcquireFinishTime = this.DiagnosticsEventManager.AcquireActorLockFinish(
                         actor,
                         lockAcquireStartTime);
+
+                    ActorTrace.Source.WriteInfoWithId(
+                        TraceType,
+                        this.traceId,
+                        "Acquired lock for actor: {0}, actor method: {1}",
+                        actorId,
+                        actorMethodContext.MethodName);
 
                     retval =
                         await
@@ -1296,6 +1316,11 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                         ex.ToString());
                 }
             }
+
+            ActorTrace.Source.WriteInfoWithId(
+                    TraceType,
+                    this.traceId,
+                    $"Load reminders complete.");
         }
 
         private Task RegisterOrUpdateReminderAsync(

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminder.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminder.cs
@@ -124,6 +124,14 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             {
                 try
                 {
+                    this.actorManager.TraceSource.WriteInfoWithId(
+                        TraceType,
+                        this.actorManager.GetActorTraceId(this.OwnerActorId),
+                        "Arming timer for reminder ({0}), actor: ({1}), newDueTime: ({2})",
+                        this.Name,
+                        this.OwnerActorId.GetStorageKey(),
+                        newDueTime);
+
                     snap.Change(newDueTime, Timeout.InfiniteTimeSpan);
                 }
                 catch (Exception e)

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderData.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderData.cs
@@ -65,7 +65,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         public override string ToString()
         {
-            return $"ActorId: {this.ActorId} Name: {this.Name} DueTime: {this.DueTime} Period: {this.Period} State: {this.State} LogicalCreationTime: {this.LogicalCreationTime}";
+            return $"ActorId: ({this.ActorId.GetStorageKey()}), Name: ({this.Name}), DueTime: ({this.DueTime}), Period: ({this.Period}), State: ({this.State}), LogicalCreationTime: ({this.LogicalCreationTime})";
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderState.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderState.cs
@@ -39,9 +39,10 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 this.nextDueTime = ComputeRemainingTime(currentLogicalTime, reminderCompletedData.LogicalTime, reminder.Period);
                 ActorTrace.Source.WriteInfo(
                     TraceType,
-                    "Next Due Time for Reminder: ({0}), Actor: ({1}), Reminder Completed Time: ({2}), Period: ({3}) is ({4})",
+                    "ComputeRemainingTime - Reminder: ({0}), Actor: ({1}), Current Logical Time: ({2}), Reminder Completed Time: ({3}), Period ({4}), Next Due Time: ({5})",
                     reminder.Name,
                     reminder.ActorId.GetStorageKey(),
+                    currentLogicalTime,
                     reminderCompletedData.LogicalTime,
                     reminder.Period,
                     this.nextDueTime);
@@ -51,9 +52,10 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 this.nextDueTime = ComputeRemainingTime(currentLogicalTime, reminder.LogicalCreationTime, reminder.DueTime);
                 ActorTrace.Source.WriteInfo(
                     TraceType,
-                    "Next Due Time for Reminder: ({0}), Actor: ({1}), Reminder Creation Time: ({2}), Due Time: ({3}) is ({4})",
+                    "ComputeRemainingTime - Reminder: ({0}), Actor: ({1}), Current Logical Time: ({2}), Reminder Creation Time: ({3}), Due Time: ({4}), Next Due Time: ({5})",
                     reminder.Name,
                     reminder.ActorId.GetStorageKey(),
+                    currentLogicalTime,
                     reminder.LogicalCreationTime,
                     reminder.DueTime,
                     this.nextDueTime);

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderState.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderState.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
     using System;
+    using System.Diagnostics;
     using System.Runtime.Serialization;
     using System.Threading;
 
@@ -15,6 +16,8 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
     [DataContract(Name = "ActorReminderState")]
     public class ActorReminderState : IActorReminderState
     {
+        private const string TraceType = "ActorReminderState";
+
         [DataMember(Name = "Reminder", Order = 0, IsRequired = true)]
         private readonly ActorReminderData reminder;
 
@@ -34,10 +37,26 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             if (reminderCompletedData != null)
             {
                 this.nextDueTime = ComputeRemainingTime(currentLogicalTime, reminderCompletedData.LogicalTime, reminder.Period);
+                ActorTrace.Source.WriteInfo(
+                    TraceType,
+                    "Next Due Time for Reminder: ({0}), Actor: ({1}), Reminder Completed Time: ({2}), Period: ({3}) is ({4})",
+                    reminder.Name,
+                    reminder.ActorId.GetStorageKey(),
+                    reminderCompletedData.LogicalTime,
+                    reminder.Period,
+                    this.nextDueTime);
             }
             else
             {
                 this.nextDueTime = ComputeRemainingTime(currentLogicalTime, reminder.LogicalCreationTime, reminder.DueTime);
+                ActorTrace.Source.WriteInfo(
+                    TraceType,
+                    "Next Due Time for Reminder: ({0}), Actor: ({1}), Reminder Creation Time: ({2}), Due Time: ({3}) is ({4})",
+                    reminder.Name,
+                    reminder.ActorId.GetStorageKey(),
+                    reminder.LogicalCreationTime,
+                    reminder.DueTime,
+                    this.nextDueTime);
             }
         }
 

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/NullActorStateProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/NullActorStateProvider.cs
@@ -260,6 +260,12 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             var key = CreateReminderStorageKey(actorId, state.Name);
             var reminderData = new ActorReminderData(actorId, state, TimeSpan.Zero);
 
+            ActorTrace.Source.WriteInfoWithId(
+                TraceType,
+                this.traceId,
+                "Saving Reminder - {0}",
+                reminderData);
+
             this.stateDictionary.AddOrUpdate(key, reminderData, (s, o) => reminderData);
 
             return Task.FromResult(true);

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ReliableCollectionsActorStateProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ReliableCollectionsActorStateProvider.cs
@@ -445,6 +445,12 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             var reminderData = new ActorReminderData(actorId, reminder, this.logicalTimeManager.CurrentLogicalTime);
             var data = ActorReminderDataSerializer.Serialize(reminderData);
 
+            ActorTrace.Source.WriteInfoWithId(
+                TraceType,
+                this.traceId,
+                "Saving Reminder - {0}",
+                reminderData);
+
             await this.stateProviderHelper.ExecuteWithRetriesAsync(
                 async () =>
                 {
@@ -1131,6 +1137,12 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
         private async Task<IActorReminderCollection> EnumerateRemindersAsync(CancellationToken cancellationToken)
         {
+            ActorTrace.Source.WriteInfoWithId(
+                TraceType,
+                this.traceId,
+                "Enumerating all reminders. Current Logical Time - {0}",
+                this.logicalTimeManager.CurrentLogicalTime);
+
             var reminderCollection = new ActorReminderCollection();
             var reminderCompletedDataDict = await this.GetReminderCompletedDataMapAsync(null, cancellationToken);
 


### PR DESCRIPTION
Adding reminder related tracing for following paths - 
- Register Reminder
  - Saving reminder in state provider
- Unregister Reminder 
- Firing Reminder 
  - Arming Reminder
- Reminder Next Due Time Computation 
- Loading Reminders when actor primary starts/moves
