### PR TITLE
Make build.yml trigger for all release_* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,12 @@ on:
   push:
     branches:
       - develop
-      - release_4*
-    tags:
-      - v*
+      - 'release_*'
     
   pull_request:
     branches: 
     - develop
-    - release_4*
+    - 'release_*'
 
 jobs:
   build:


### PR DESCRIPTION
To enable PR validation builds for all release_* branches in addition to the develop branch.

Also remove v* tag trigger because it's not being used.