### PR TITLE
Update NuGet packages to latest versions

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>3</BuildVersion>
+    <BuildVersion>4</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.ServiceFabric" Version="$(NugetPkg_Version_Microsoft_ServiceFabric)" />
     <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_Diagnostics_Internal)" />
     <PackageReference Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal)" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Actors\Microsoft.ServiceFabric.Actors.csproj" />

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />

--- a/src/netstandard/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj
+++ b/src/netstandard/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="$(NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal)" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(SourceCodeDir)SR.resx">

--- a/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.45" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.1" />

--- a/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
@@ -6,15 +6,14 @@
     <AssemblyName>Microsoft.ServiceFabric.Actors.StateMigration.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.45" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/ActorManagerTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/ActorManagerTests.cs
@@ -51,12 +51,12 @@ namespace Microsoft.ServiceFabric.Actors.Tests
         /// Verifies ActorManager close.
         /// </summary>
         [Fact]
-        public void VerifyClose()
+        public async Task VerifyClose()
         {
             this.ResetActorManager();
             this.RegisterReminders();
             this.VerifyReminderPresence();
-            this.actorManager.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+            await this.actorManager.CloseAsync(CancellationToken.None);
             this.VerifyNoReminders();
         }
 
@@ -77,10 +77,10 @@ namespace Microsoft.ServiceFabric.Actors.Tests
         /// Verify FireReminder after close.
         /// </summary>
         [Fact]
-        public void VerifyFireReminderNoThrow()
+        public async Task VerifyFireReminderNoThrow()
         {
             this.ResetActorManager();
-            this.actorManager.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+            await this.actorManager.CloseAsync(CancellationToken.None);
 
             var reminder = new ActorReminder(
                 ActorId.CreateRandom(),
@@ -90,7 +90,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests
                 TimeSpan.FromMinutes(30),
                 TimeSpan.FromMinutes(30));
 
-            this.actorManager.FireReminderAsync(reminder).GetAwaiter().GetResult();
+            await this.actorManager.FireReminderAsync(reminder);
         }
 
         /// <summary>

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/DependencyInjectionTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/DependencyInjectionTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests
         /// Verify mockability for ACtors.
         /// </summary>
         [Fact]
-        public void VerifyActorMockability()
+        public async Task VerifyActorMockability()
         {
             var mockActorId = ActorId.CreateRandom();
 
@@ -70,10 +70,10 @@ namespace Microsoft.ServiceFabric.Actors.Tests
             mockActor.ServiceUri.Should().Be(mockActorService.Context.ServiceName, "ServiceUri from Actor should be same as what is coming form ServiceContext");
 
             ConsoleLogHelper.LogInfo("Verifying Actor State Mockability...");
-            mockActor.VerifyActorStateMockabilityAsync().GetAwaiter().GetResult();
+            await mockActor.VerifyActorStateMockabilityAsync();
 
             ConsoleLogHelper.LogInfo("Verifying Remider Mockability...");
-            mockActor.VerifyRemiderMockabilityAsync().GetAwaiter().GetResult();
+            await mockActor.VerifyRemiderMockabilityAsync();
 
             ConsoleLogHelper.LogInfo("Verifying Timer Mockability...");
             mockActor.VerifyTimerMockability();

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.45" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.8.1" />

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
@@ -6,15 +6,14 @@
     <AssemblyName>Microsoft.ServiceFabric.Actors.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.45" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Runtime/IdleObjectGcHandleTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Runtime/IdleObjectGcHandleTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
         [InlineData(5)]
         [InlineData(10)]
 
-        public void VerifyUseUnuseCollect(int n)
+        public async Task VerifyUseUnuseCollect(int n)
         {
             // 1. Set MaxIdleCount for IdleObjectGcHandle to N.
             // 2. Call TryUse Once.
@@ -65,7 +65,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
 
             for (var i = 0; i < n; i++)
@@ -74,7 +74,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
 
             gchandle.Unuse(false);
@@ -83,7 +83,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             gchandle.TryCollect().Should().BeTrue();
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
         [InlineData(2)]
         [InlineData(5)]
         [InlineData(10)]
-        public void VerifyUseUnuseCollectWithTimerCalls(int n)
+        public async Task VerifyUseUnuseCollectWithTimerCalls(int n)
         {
             // 1. Set MaxIdleCount for IdleObjectGcHandle to N.
             // 2. Call TryUse Once.
@@ -120,7 +120,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
 
             for (var i = 0; i < n; i++)
@@ -130,7 +130,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
 
             gchandle.Unuse(false);
@@ -140,7 +140,7 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
             gchandle.TryUse(true).Should().BeTrue();
 
@@ -149,12 +149,12 @@ namespace Microsoft.ServiceFabric.Actors.Tests.Runtime
                 tasks.Add(Task.Run(() => Assert.False(gchandle.TryCollect())));
             }
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
             gchandle.Unuse(true);
             gchandle.TryCollect().Should().BeFalse();
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
             tasks.Clear();
 
             gchandle.TryCollect().Should().BeTrue();

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
@@ -6,14 +6,13 @@
     <AssemblyName>Microsoft.ServiceFabric.Services.Remoting.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
    <TargetFramework>net6.0</TargetFramework>
-   <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>    

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/V2/ExceptionConvertors/SystemExceptionConvertorTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/V2/ExceptionConvertors/SystemExceptionConvertorTest.cs
@@ -176,7 +176,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.ExceptionConvertors
                 }
                 else if (exception is ReflectionTypeLoadException typeLoad)
                 {
-                    if (!typeLoad.Types.IsNullOrEmpty())
+                    if (typeLoad.Types?.Any() == true)
                     {
                         Assert.True(((ReflectionTypeLoadException)resultEx).Types.SequenceEqual(typeLoad.Types));
                     }
@@ -229,7 +229,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.ExceptionConvertors
             Assert.True(((AggregateException)((AggregateException)resultEx).InnerExceptions[0]).InnerExceptions.Count == 3);
             Assert.True(((AggregateException)((AggregateException)((AggregateException)resultEx).InnerExceptions[0]).InnerExceptions[0]).InnerExceptions.Count == 0);
             Assert.True(((ReflectionTypeLoadException)((AggregateException)resultEx).InnerExceptions[1]).LoaderExceptions.Length == 3);
-            Assert.True(((ReflectionTypeLoadException)((ReflectionTypeLoadException)((AggregateException)resultEx).InnerExceptions[1]).LoaderExceptions[0]).LoaderExceptions.IsNullOrEmpty());
+            Assert.False(((ReflectionTypeLoadException)((ReflectionTypeLoadException)((AggregateException)resultEx).InnerExceptions[1]).LoaderExceptions[0]).LoaderExceptions?.Any());
         }
 
         private static AggregateException NestedAggregateEx(int depth, int breadth)

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
@@ -6,14 +6,13 @@
     <AssemblyName>Microsoft.ServiceFabric.Services.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This repository was flagged for using unsecure Newtonsoft.Json package version through the xunit package dependency. In addition to the xunit packages, upgrade all packages to their latest stable versions.

Dependencies of the shipping product binaries:
- Microsoft.ServiceFabric.Services.Remoting
  - System.Reflection.Emit and System.Reflection.Emit.ILGeneration from 4.3.0 to 4.7.0
  - System.Diagnostics.DiagnosticSource from 4.3.0 to 8.0.1

Dependencies of the test projects:
- FluentAssertions from 5.9.0 to 6.12.0
- Moq from 4.13.0 to 4.20.70
- Microsoft.NET.Test.Sdk from 15.9.0 to 17.10.0
- xunit from 2.4.1 to 2.8.1
- xunit.runner.visualstudio from 2.4.1 to 2.8.1
- Microsoft.Diagnostics.Tracing.TraceEvent from 2.0.45 to 3.1.12
- System.Net.Http.WinHttpHandler from 6.0.0 to 8.0.0