### PR TITLE
Remove Microsoft.ServiceFabric.Internal references

### DIFF
--- a/nuprojs/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.nuproj
+++ b/nuprojs/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.nuproj
@@ -102,12 +102,6 @@
       <File Include="$(DropFolderNetStandard_Win)Microsoft.ServiceFabric.ReliableCollection.Interop.dll">
         <TargetPath>build\netcoreapp2.0</TargetPath>
       </File>
-      <File Include="$(DropFolderNetStandard_Win)Microsoft.ServiceFabric.Internal.dll">
-        <TargetPath>build\netcoreapp2.0</TargetPath>
-      </File>
-      <File Include="$(DropFolderNetStandard_Win)Microsoft.ServiceFabric.Internal.Strings.dll">
-        <TargetPath>build\netcoreapp2.0</TargetPath>
-      </File>
       <File Include="$(DropFolderNetStandard_Win)System.Fabric.dll">
         <TargetPath>build\netcoreapp2.0</TargetPath>
       </File>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -31,7 +31,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>5</BuildVersion>
+    <BuildVersion>7</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -22,10 +22,10 @@
 
     <!-- Set Versions. These are used for generating Assemblies and Nuget packages. -->
     <!-- Versions used for Microsoft.ServiceFabric.* nuget packages from other repos.-->
-    <NugetPkg_Version_Microsoft_ServiceFabric>11.0.1004</NugetPkg_Version_Microsoft_ServiceFabric>
-    <NugetPkg_Version_Microsoft_ServiceFabric_Diagnostics_Internal>8.0.1004</NugetPkg_Version_Microsoft_ServiceFabric_Diagnostics_Internal>
-    <NugetPkg_Version_Microsoft_ServiceFabric_Data>8.0.1004</NugetPkg_Version_Microsoft_ServiceFabric_Data>
-    <NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal>8.0.1004</NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal>
+    <NugetPkg_Version_Microsoft_ServiceFabric>11.0.1928</NugetPkg_Version_Microsoft_ServiceFabric>
+    <NugetPkg_Version_Microsoft_ServiceFabric_Diagnostics_Internal>8.0.1928</NugetPkg_Version_Microsoft_ServiceFabric_Diagnostics_Internal>
+    <NugetPkg_Version_Microsoft_ServiceFabric_Data>8.0.1928</NugetPkg_Version_Microsoft_ServiceFabric_Data>
+    <NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal>8.0.1928</NugetPkg_Version_Microsoft_ServiceFabric_FabricTransport_Internal>
 
     <!-- Version for binaries, nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->

--- a/src/Microsoft.ServiceFabric.Actors/ActorId.cs
+++ b/src/Microsoft.ServiceFabric.Actors/ActorId.cs
@@ -5,15 +5,12 @@
 
 namespace Microsoft.ServiceFabric.Actors
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Runtime.Serialization;
     using System.Text;
     using Microsoft.ServiceFabric.Services;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// The ActorId represents the identity of an actor within an actor service. This is used to identify the partition of the actor service inside which the actor will run, see <see cref="GetPartitionKey"/>

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorLockContentionCounterWriter.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorLockContentionCounterWriter.cs
@@ -5,10 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
-    using FabricBaselessPerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricBaselessPerformanceCounterWriter;
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
+    using System.Fabric.Common;
 
     // This class modifies the value of the performance counter that represents the
     // number of pending actor calls that are waiting for the actor lock.

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorMethodExceptionFrequencyCounterWriter.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorMethodExceptionFrequencyCounterWriter.cs
@@ -5,10 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
-    using FabricBaselessPerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricBaselessPerformanceCounterWriter;
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
+    using System.Fabric.Common;
 
     // This class modifies the value of the performance counter that represents the
     // frequency at which a particular actor method throws exceptions.

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorMethodExecTimeCounterWriter.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorMethodExecTimeCounterWriter.cs
@@ -5,10 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
-    using FabricPerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterWriter;
+    using System.Fabric.Common;
 
     // This class modifies the value of the performance counter that represents the
     // time taken to execute a particular actor method.

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorMethodFrequencyCounterWriter.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorMethodFrequencyCounterWriter.cs
@@ -5,10 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
-    using FabricBaselessPerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricBaselessPerformanceCounterWriter;
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
+    using System.Fabric.Common;
 
     // This class modifies the value of the performance counter that represents the
     // frequency at which a particular actor method is invoked.

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorPerformanceCounters.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorPerformanceCounters.cs
@@ -5,15 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
-    using FabricPerformanceCounterCategoryType = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterCategoryType;
-    using FabricPerformanceCounterDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterDefinition;
-    using FabricPerformanceCounterSetDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetDefinition;
-    using FabricPerformanceCounterType = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterType;
-    using IFabricPerformanceCountersDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.IFabricPerformanceCountersDefinition;
+    using System.Fabric.Common;
 
     internal class ActorPerformanceCounters : IFabricPerformanceCountersDefinition
     {

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorSaveStateTimeCounterWriter.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorSaveStateTimeCounterWriter.cs
@@ -5,10 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
-    using FabricPerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterWriter;
+    using System.Fabric.Common;
 
     // This class modifies the value of the performance counter that represents the
     // time taken to save actor state.

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/PerformanceCounterProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/PerformanceCounterProvider.cs
@@ -5,22 +5,15 @@
 
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
+    using System.Fabric.Common;
     using System.Reflection;
     using System.Text;
     using Microsoft.ServiceFabric.Actors.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting;
     using Microsoft.ServiceFabric.Services.Remoting.Description;
     using Microsoft.ServiceFabric.Services.Remoting.Diagnostic;
-    using FabricAverageCount64PerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricAverageCount64PerformanceCounterWriter;
-    using FabricNumberOfItems64PerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricNumberOfItems64PerformanceCounterWriter;
-    using FabricPerformanceCounterDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterDefinition;
-    using FabricPerformanceCounterSet = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSet;
-    using FabricPerformanceCounterSetDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetDefinition;
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
 
     internal class PerformanceCounterProvider : IDisposable
     {

--- a/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
+++ b/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
@@ -36,11 +36,4 @@
       <LastGenOutput>SR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V1/FabricTransport/Runtime/FabricTransportActorServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V1/FabricTransport/Runtime/FabricTransportActorServiceRemotingListener.cs
@@ -5,9 +5,8 @@
 
 namespace Microsoft.ServiceFabric.Actors.Remoting.V1.FabricTransport.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System.Fabric;
+    using System.Fabric.Common;
     using Microsoft.ServiceFabric.Actors.Generator;
     using Microsoft.ServiceFabric.Actors.Remoting.FabricTransport;
     using Microsoft.ServiceFabric.Actors.Remoting.V1.Runtime;
@@ -16,7 +15,6 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V1.FabricTransport.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V1.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V1.Runtime;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     ///     An <see cref="IServiceRemotingListener"/>

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V1/Runtime/ActorServiceRemotingDispatcher.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V1/Runtime/ActorServiceRemotingDispatcher.cs
@@ -5,10 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Actors.Remoting.V1.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Runtime.Serialization;
     using System.Threading;
@@ -19,8 +18,6 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V1.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V1;
     using Microsoft.ServiceFabric.Services.Remoting.V1.Runtime;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// Provides an implementation of <see cref="IServiceRemotingMessageHandler"/> that can dispatch

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V2/FabricTransport/Runtime/FabricTransportActorServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V2/FabricTransport/Runtime/FabricTransportActorServiceRemotingListener.cs
@@ -5,11 +5,10 @@
 
 namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using Microsoft.ServiceFabric.Actors.Generator;
     using Microsoft.ServiceFabric.Actors.Migration;
     using Microsoft.ServiceFabric.Actors.Remoting.FabricTransport;
@@ -20,7 +19,6 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.FabricTransport.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.V2;
     using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     ///     An <see cref="IServiceRemotingListener"/>

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V2/Runtime/ActorServiceRemotingDispatcher.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V2/Runtime/ActorServiceRemotingDispatcher.cs
@@ -5,10 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Actors.Remoting.V2.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
@@ -19,7 +18,6 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.V2;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Builder;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// Provides an implementation of <see cref="IServiceRemotingMessageHandler"/> that can dispatch

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderDataSerializer.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorReminderDataSerializer.cs
@@ -5,11 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
+    using System.Fabric.Common;
     using System.IO;
     using System.Text;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
 
     internal sealed class ActorReminderDataSerializer
     {

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorRuntime.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorRuntime.cs
@@ -5,17 +5,15 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Actors.Diagnostics;
     using Microsoft.ServiceFabric.Actors.Generator;
     using Microsoft.ServiceFabric.Services.Runtime;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// Contains methods to register actor and actor service types with Service Fabric runtime. Registering the types allows the runtime to create instances of the actor and the actor service. See https://docs.microsoft.com/azure/service-fabric/service-fabric-reliable-actors-lifecycle for more information on the lifecycle of an actor.

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateChange.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateChange.cs
@@ -5,10 +5,8 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
+    using System.Fabric.Common;
 
     /// <summary>
     /// Represents a change to an actor state with a given state name.

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateManager.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateManager.cs
@@ -5,17 +5,15 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Data;
     using Microsoft.ServiceFabric.Services.Common;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
     using SR = Microsoft.ServiceFabric.Actors.SR;
 
     internal sealed class ActorStateManager : IActorStateManager

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/BinaryReaderWriterExtensions.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/BinaryReaderWriterExtensions.cs
@@ -5,13 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
+    using System.Fabric.Common;
     using System.IO;
     using System.Runtime.InteropServices;
     using System.Text;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
 
     internal static class BinaryReaderWriterExtensions
     {

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProviderBase.cs
@@ -5,12 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Fabric.Health;
     using System.Globalization;
     using System.IO;
@@ -26,10 +25,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
 
     using CopyCompletionCallback = System.Action<System.Fabric.KeyValueStoreEnumerator>;
     using DataLossCallback = System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>;
-    using FabricDirectory = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricDirectory;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
     using ReplicationCallback = System.Action<System.Collections.Generic.IEnumerator<System.Fabric.KeyValueStoreNotification>>;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
     using RestoreCompletedCallback = System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task>;
     using SR = Microsoft.ServiceFabric.Actors.SR;
 

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProvider_v2.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/KvsActorStateProvider_v2.cs
@@ -5,16 +5,13 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Threading;
     using System.Threading.Tasks;
     using CopyCompletionCallback = System.Action<System.Fabric.KeyValueStoreEnumerator>;
     using DataLossCallback = System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>>;
-    using KeyValueStoreReplica_V2 = Microsoft_ServiceFabric_Internal::System.Fabric.KeyValueStoreReplica_V2;
-    using KeyValueStoreReplicaSettings_V2 = Microsoft_ServiceFabric_Internal::System.Fabric.KeyValueStoreReplicaSettings_V2;
     using ReplicationCallback = System.Action<System.Collections.Generic.IEnumerator<System.Fabric.KeyValueStoreNotification>>;
     using RestoreCompletedCallback = System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task>;
 

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/LogicalTimestampSerializer.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/LogicalTimestampSerializer.cs
@@ -5,11 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
+    using System.Fabric.Common;
     using System.IO;
     using System.Text;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
 
     internal sealed class LogicalTimestampSerializer
     {

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/NullActorStateProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/NullActorStateProvider.cs
@@ -5,19 +5,17 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Actors.Query;
     using Microsoft.ServiceFabric.Data;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
     using SR = Microsoft.ServiceFabric.Actors.SR;
 
     internal class NullActorStateProvider : IActorStateProvider, IStateProvider, IActorStateProviderInternal

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ReliableCollectionsActorStateProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ReliableCollectionsActorStateProvider.cs
@@ -5,12 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Linq;
     using System.Text;
@@ -21,8 +20,6 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
     using Microsoft.ServiceFabric.Data;
     using Microsoft.ServiceFabric.Data.Collections;
     using Microsoft.ServiceFabric.Services;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
     using SR = Microsoft.ServiceFabric.Actors.SR;
 
     /// <summary>

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ReminderCompletedDataSerializer.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ReminderCompletedDataSerializer.cs
@@ -5,11 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
+    using System.Fabric.Common;
     using System.IO;
     using System.Text;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
 
     internal sealed class ReminderCompletedDataSerializer
     {

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/VolatileActorStateProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/VolatileActorStateProvider.cs
@@ -5,12 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Actors.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.IO;
     using System.Linq;
@@ -29,8 +28,6 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
         VolatileActorStateProvider.ActorStateType,
         string,
         VolatileActorStateProvider.ActorStateData>;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
     using SR = Microsoft.ServiceFabric.Actors.SR;
 
     /// <summary>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Diagnostic/ServicePerformanceCounterProvider.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Diagnostic/ServicePerformanceCounterProvider.cs
@@ -5,20 +5,13 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.Diagnostic
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
+    using System.Fabric.Common;
     using System.Linq;
     using System.Reflection;
     using System.Text;
     using Microsoft.ServiceFabric.Services.Remoting.Description;
-    using FabricAverageCount64PerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricAverageCount64PerformanceCounterWriter;
-    using FabricNumberOfItems64PerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricNumberOfItems64PerformanceCounterWriter;
-    using FabricPerformanceCounterDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterDefinition;
-    using FabricPerformanceCounterSet = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSet;
-    using FabricPerformanceCounterSetDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetDefinition;
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
 
     internal class ServicePerformanceCounterProvider : IDisposable
     {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Diagnostic/ServiceRemotingPerformanceCounters.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Diagnostic/ServiceRemotingPerformanceCounters.cs
@@ -5,15 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.Diagnostic
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
-    using FabricPerformanceCounterCategoryType = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterCategoryType;
-    using FabricPerformanceCounterDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterDefinition;
-    using FabricPerformanceCounterSetDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetDefinition;
-    using FabricPerformanceCounterType = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterType;
-    using IFabricPerformanceCountersDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.IFabricPerformanceCountersDefinition;
+    using System.Fabric.Common;
 
     internal class ServiceRemotingPerformanceCounters : IFabricPerformanceCountersDefinition
     {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/FabricTransportRemotingSettings.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/FabricTransportRemotingSettings.cs
@@ -5,12 +5,10 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.FabricTransport
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using Microsoft.ServiceFabric.FabricTransport;
-    using AppTrace = Microsoft_ServiceFabric_Internal::System.Fabric.Common.AppTrace;
     using Constants = Microsoft.ServiceFabric.Services.Remoting.V2.Constants;
 
     /// <summary>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/Runtime/FabricTransportRemotingListenerSettings.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/Runtime/FabricTransportRemotingListenerSettings.cs
@@ -5,14 +5,12 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using Microsoft.ServiceFabric.FabricTransport;
     using Microsoft.ServiceFabric.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V2;
-    using AppTrace = Microsoft_ServiceFabric_Internal::System.Fabric.Common.AppTrace;
     using Constants = Microsoft.ServiceFabric.Services.Remoting.V2.Constants;
 
     /// <summary>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
@@ -29,11 +29,4 @@
       <LastGenOutput>SR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V1/FabricTransport/Runtime/FabricTransportMessagingHandler.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V1/FabricTransport/Runtime/FabricTransportMessagingHandler.cs
@@ -5,15 +5,13 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V1.FabricTransport.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
+    using System.Fabric.Common;
     using System.Runtime.Serialization;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.FabricTransport;
     using Microsoft.ServiceFabric.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V1.Runtime;
-    using ReleaseAssert = Microsoft_ServiceFabric_Internal::System.Fabric.Common.ReleaseAssert;
 
     internal class FabricTransportMessagingHandler : IFabricTransportMessageHandler
     {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V1/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V1/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
@@ -5,10 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V1.FabricTransport.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.FabricTransport.Runtime;
@@ -16,7 +15,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V1.FabricTransport.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V1.Runtime;
-    using AppTrace = Microsoft_ServiceFabric_Internal::System.Fabric.Common.AppTrace;
 
     /// <summary>
     ///     An <see cref="Microsoft.ServiceFabric.Services.Remoting.Runtime.IServiceRemotingListener"/> that uses

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V1/RemoteExceptionInformation.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V1/RemoteExceptionInformation.cs
@@ -5,16 +5,14 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V1
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.IO;
     using System.Runtime.Serialization;
     using System.Text;
     using Microsoft.ServiceFabric.Services.Common;
     using Microsoft.ServiceFabric.Services.Communication;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// Represents the fault type used by Service Remoting to transfer the exception details from the Service Replica to the client.

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V1/Runtime/ServiceRemotingDispatcher.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V1/Runtime/ServiceRemotingDispatcher.cs
@@ -5,12 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V1.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.Runtime.ExceptionServices;
     using System.Threading;
@@ -19,7 +18,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V1.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.Diagnostic;
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V1.Builder;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// Provides an implementation of <see cref="IServiceRemotingMessageHandler"/> that can dispatch

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/Diagnostic/ServiceRemotingPerformanceCounterProvider.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/Diagnostic/ServiceRemotingPerformanceCounterProvider.cs
@@ -5,18 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
+    using System.Fabric.Common;
     using System.Linq;
     using System.Text;
-    using FabricAverageCount64PerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricAverageCount64PerformanceCounterWriter;
-    using FabricNumberOfItems64PerformanceCounterWriter = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricNumberOfItems64PerformanceCounterWriter;
-    using FabricPerformanceCounterDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterDefinition;
-    using FabricPerformanceCounterSet = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSet;
-    using FabricPerformanceCounterSetDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetDefinition;
-    using FabricPerformanceCounterSetInstance = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetInstance;
 
     internal class ServiceRemotingPerformanceCounterProvider : IDisposable
     {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/Diagnostic/ServiceRemotingPerformanceCounters.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/Diagnostic/ServiceRemotingPerformanceCounters.cs
@@ -5,15 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Diagnostic
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Generic;
-    using FabricPerformanceCounterCategoryType = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterCategoryType;
-    using FabricPerformanceCounterDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterDefinition;
-    using FabricPerformanceCounterSetDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterSetDefinition;
-    using FabricPerformanceCounterType = Microsoft_ServiceFabric_Internal::System.Fabric.Common.FabricPerformanceCounterType;
-    using IFabricPerformanceCountersDefinition = Microsoft_ServiceFabric_Internal::System.Fabric.Common.IFabricPerformanceCountersDefinition;
+    using System.Fabric.Common;
 
     internal class ServiceRemotingPerformanceCounters : IFabricPerformanceCountersDefinition
     {

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Runtime/FabricTransportServiceRemotingListener.cs
@@ -5,10 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System.Collections.Generic;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.FabricTransport.V2.Runtime;
@@ -16,8 +15,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Messaging;
     using Microsoft.ServiceFabric.Services.Remoting.V2.Runtime;
-    using AppTrace = Microsoft_ServiceFabric_Internal::System.Fabric.Common.AppTrace;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     ///     An <see cref="Microsoft.ServiceFabric.Services.Remoting.Runtime.IServiceRemotingListener"/> that uses

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/Messaging/BufferPoolManager.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/Messaging/BufferPoolManager.cs
@@ -5,10 +5,8 @@
 
 namespace Microsoft.ServiceFabric.Services.Remoting.V2.Messaging
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
-    using SynchronizedPool = Microsoft_ServiceFabric_Internal::System.Fabric.Common.SynchronizedPool<PooledBuffer>;
+    using System.Fabric.Common;
 
     /// <summary>
     /// You can use the BufferManager class to manage a buffer pool.
@@ -23,7 +21,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Messaging
         private const int DefaultBufferLimit = 100;
 
         // Not using SynchonizedBufferPool as it has shrink buffer logic , which we don't need yet
-        private readonly SynchronizedPool bufferPool;
+        private readonly SynchronizedPool<PooledBuffer> bufferPool;
 
         private readonly Allocator allocator;
 
@@ -37,7 +35,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Messaging
         public BufferPoolManager(int segmentSize = DefaultSegmentSize, int bufferLimit = DefaultBufferLimit)
         {
             this.limit = bufferLimit;
-            this.bufferPool = new SynchronizedPool(this.limit);
+            this.bufferPool = new SynchronizedPool<PooledBuffer>(this.limit);
             this.allocator = new Allocator(segmentSize);
             ServiceTrace.Source.WriteInfo(
                 "BufferPoolManager",

--- a/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/Runtime/WcfCommunicationListener.cs
+++ b/src/Microsoft.ServiceFabric.Services.Wcf/Communication/Wcf/Runtime/WcfCommunicationListener.cs
@@ -5,10 +5,9 @@
 
 namespace Microsoft.ServiceFabric.Services.Communication.Wcf.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Globalization;
     using System.ServiceModel;
     using System.ServiceModel.Channels;
@@ -17,7 +16,6 @@ namespace Microsoft.ServiceFabric.Services.Communication.Wcf.Runtime
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Services.Communication.Runtime;
-    using AppTrace = Microsoft_ServiceFabric_Internal::System.Fabric.Common.AppTrace;
 
     /// <summary>
     /// A Windows Communication Foundation based listener for Service Fabric based stateless or stateful service.

--- a/src/Microsoft.ServiceFabric.Services.Wcf/Microsoft.ServiceFabric.Services.Wcf.csproj
+++ b/src/Microsoft.ServiceFabric.Services.Wcf/Microsoft.ServiceFabric.Services.Wcf.csproj
@@ -26,11 +26,4 @@
       <LastGenOutput>SR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Microsoft.ServiceFabric.Services/Client/ServicePartitionResolver.cs
+++ b/src/Microsoft.ServiceFabric.Services/Client/ServicePartitionResolver.cs
@@ -5,17 +5,14 @@
 
 namespace Microsoft.ServiceFabric.Services.Client
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Collections.Concurrent;
-    using System.Diagnostics;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Fabric.Description;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Services.Communication.Client;
-    using TimeoutHelper = Microsoft_ServiceFabric_Internal::System.Fabric.Common.TimeoutHelper;
 
     /// <summary>
     /// Represents a delegate to create a FabricClient object.

--- a/src/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services.csproj
+++ b/src/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services.csproj
@@ -27,11 +27,4 @@
       <LastGenOutput>SR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Microsoft.ServiceFabric.Services/Runtime/ServiceRuntime.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/ServiceRuntime.cs
@@ -5,13 +5,11 @@
 
 namespace Microsoft.ServiceFabric.Services.Runtime
 {
-    extern alias Microsoft_ServiceFabric_Internal;
-
     using System;
     using System.Fabric;
+    using System.Fabric.Common;
     using System.Threading;
     using System.Threading.Tasks;
-    using Requires = Microsoft_ServiceFabric_Internal::System.Fabric.Common.Requires;
 
     /// <summary>
     /// The static class that provides methods to register reliable services with Service Fabric runtime.

--- a/src/netstandard/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors_netstandard.csproj
+++ b/src/netstandard/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors_netstandard.csproj
@@ -51,11 +51,4 @@
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj" />
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services_netstandard.csproj" />
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/netstandard/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj
+++ b/src/netstandard/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj
@@ -43,11 +43,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services_netstandard.csproj" />
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/netstandard/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services_netstandard.csproj
+++ b/src/netstandard/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services_netstandard.csproj
@@ -36,11 +36,4 @@
       <LastGenOutput>SR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Target Name="AddCustomAliases" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Condition="'%(FileName)' == 'Microsoft.ServiceFabric.Internal' AND '%(ReferencePath.NuGetPackageId)' == 'Microsoft.ServiceFabric'">
-        <Aliases>Microsoft_ServiceFabric_Internal</Aliases>
-      </ReferencePath>
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
The `Microsoft.ServiceFabric.Internal.dll` was introduced years ago as an assembly meant to be used by the Service Fabric SDK packages instead of the `System.Fabric.dll`. The `Microsoft.ServiceFabric.Internal` assembly includes a subset of the types from `System.Fabric` with the exception of a few internal types.

However, both of these DLLs are now included in the `Microsoft.ServiceFabric` NuGet package and most Service Fabric .NET services, reference both of them. With the original intent abandoned, there is no clear value in keeping the `Microsoft.ServiceFabric.Internal.dll`. Removing it from the Service Fabric Runtime and SDK eliminates the cost of maintaining it and reduces unnecessary complexity and cognitive load on the engineers.

See [Windows Fabric PR](https://dev.azure.com/msazure/One/_git/WindowsFabric/pullrequest/10327808) for more.