### PR TITLE
Fix CancelOnTimerWithLargeRetryDelay test flakiness due to Stopwatch imprecision

### DIFF
--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServicePartitionClientTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServicePartitionClientTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ServiceFabric.Services.Tests
                 retryDelay);
             sw.Stop();
 
-            sw.ElapsedMilliseconds.Should().BeGreaterThan((long)clientRetryTimeout.TotalMilliseconds, "Should be longer than the ClientRetryTimeout.");
+            sw.ElapsedMilliseconds.Should().BeGreaterThan((long)clientRetryTimeout.TotalMilliseconds - StopwatchPrecisionMs, "Should be longer than the ClientRetryTimeout.");
             result.ExceptionFromInvoke.Should().BeAssignableTo(typeof(OperationCanceledException), $"Should indicate a canceled operation. {result.ExceptionFromInvoke}");
             result.CallCount.Should().BeLessThan(retryCount, "Should cancel before token is signaled.");
             result.CancellationTokenSource.Token.IsCancellationRequested.Should().Be(false, "Cancellation should have occured due to the timer.");


### PR DESCRIPTION
CancelOnTimerWithLargeRetryDelay fails on some environments due 
to the fact that Stopwatch class may report incorrect timing results on 
different processors, as noted in official documentation: 
https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch?view=net-8.0