### PR TITLE
Increase margin of error for Stopwatch based on measurements

### DIFF
--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServicePartitionClientTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServicePartitionClientTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ServiceFabric.Services.Tests
         // Due to bugs in BIOS or Hardware Abstraction Layer, Stopwatch sometimes reports slightly smaller value, as
         // documented here: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch?view=net-8.0
         // We need to account for that possibility.
-        private static readonly long StopwatchPrecisionMs = 10;
+        private static readonly long StopwatchPrecisionMs = 25;
 
         /// <summary>
         /// Tests handling of cancellation by the passed cancellation token.


### PR DESCRIPTION
ServicePartitionClientTests are flaky due to documented imprecision of Stopwatch class.
Based on empirical measurements, we're increasing margin of error from 10ms to 25ms.

Internal ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/29276368