### PR TITLE
Avoid overriding NuGetPackageVersion from environment variable

### DIFF
--- a/properties/service_fabric_nuget.props
+++ b/properties/service_fabric_nuget.props
@@ -4,7 +4,7 @@
 
   <!-- Set Versions. These are used for generating Nuget packages. -->
   <PropertyGroup>
-    <NuGetPackageVersion>$(MajorVersion).$(MinorVersion).$(BuildVersion)</NuGetPackageVersion>
+    <NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">$(MajorVersion).$(MinorVersion).$(BuildVersion)</NuGetPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We need to allow `NuGetPackageVersion` to be provided as an environment variable. 
Currently, the value is unconditionally reassigned to values provided 
in `service_fabric_common.props`:

<img width="868" alt="propertyReassignment1" src="https://github.com/user-attachments/assets/4600bd4c-9873-4bb2-8ea9-56df2b0f9896">
