### PR TITLE
Resolving vulnerable transitive dependencies

### DIFF
--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
@@ -28,6 +28,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.2.6" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Overriding versions of transitive dependencies -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/netstandard/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration_netstandard.csproj
+++ b/src/netstandard/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration_netstandard.csproj
@@ -33,4 +33,11 @@
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj" />
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services_netstandard.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Overriding versions of transitive dependencies -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
 </Project>

--- a/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="$(RepoRoot)src\netstandard\Microsoft.ServiceFabric.Actors.KVSToRCMigration\Microsoft.ServiceFabric.Actors.KVSToRCMigration_netstandard.csproj" />
     <ProjectReference Include="$(RepoRoot)src\netstandard\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services_netstandard.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Overriding versions of transitive dependencies -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Overriding versions of transitive dependencies that were flagged as vulnerable on nuget.org.

Internal ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/29603592