### PR TITLE
Enabling .NET 9 tests for SF SDK packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: '9.0.x'
       - name: Build Everything
         shell: powershell
-        run: dotnet build code.sln
+        run: dotnet build buildAll.proj
       - name: Run Tests
         run: dotnet test code.sln --configuration release --nologo --settings test\unittests\default.runsettings --results-directory ${{ env.TEST_RESULT_DIR }} --logger trx
       - name: upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: '9.0.x'
       - name: Build Everything
         shell: powershell
-        run: ./build.ps1
+        run: dotnet build code.sln
       - name: Run Tests
         run: dotnet test code.sln --configuration release --nologo --settings test\unittests\default.runsettings --results-directory ${{ env.TEST_RESULT_DIR }} --logger trx
       - name: upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
       TEST_RESULT_DIR: drop\testresults
     steps:
       - uses: actions/checkout@v1
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       - name: Build Everything
         shell: powershell
         run: ./build.ps1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
+      - name: Check dotnet version
+        run: dotnet --version
+        - name: Check installed SDK versions
+        run: dotnet sdk check
       - name: Build Everything
         shell: powershell
         run: ./build.ps1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: '9.0.x'
       - name: Check dotnet version
         run: dotnet --version
-        - name: Check installed SDK versions
+      - name: Check installed SDK versions
         run: dotnet sdk check
       - name: Build Everything
         shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-      - name: Check dotnet version
-        run: dotnet --version
-      - name: Check installed SDK versions
-        run: dotnet sdk check
       - name: Build Everything
         shell: powershell
         run: ./build.ps1

--- a/buildAll.proj
+++ b/buildAll.proj
@@ -14,12 +14,12 @@
     <Message Text="SUCCESS!  Generated binaries and packages are dropped at $(CurrentDir)drop\$(Configuration)" Importance="High"/>
   </Target>
 
-  <Target Name="BuildAll" DependsOnTargets="RestorePackagesProd;BuildProd;CopyProdBinaries;GenerateNugetPackages">
+  <Target Name="BuildAll" DependsOnTargets="RestorePackagesProd;RestorePackagesTest;BuildProd;BuildTest;CopyProdBinaries;GenerateNugetPackages">
     <Message Text="SUCCESS!  Generated binaries and packages are dropped at $(CurrentDir)drop\$(Configuration)" Importance="High"/>
   </Target>
 
   <!-- Builds code, this target doesn't generates nuget packages. -->
-  <Target Name="BuildCode" DependsOnTargets="RestorePackagesProd;CleanAll;BuildProd;CopyProdBinaries">
+  <Target Name="BuildCode" DependsOnTargets="RestorePackagesProd;RestorePackagesTest;CleanAll;BuildProd;BuildTest;CopyProdBinaries">
     <Message Text="SUCCESS!  Generated binaries are dropped at $(CurrentDir)drop\$(Configuration)" Importance="High"/>
   </Target>
 
@@ -77,7 +77,7 @@
     <RemoveDir Directories="$(CurrentDir)\drop"/>
     
     <Message Text="Cleaning all projects ..."/>
-    <CallTarget Targets="CleanProd" />
+    <CallTarget Targets="CleanProd;CleanTest" />
   </Target>
   
   <Target Name="CleanProd">

--- a/buildAll.proj
+++ b/buildAll.proj
@@ -14,12 +14,12 @@
     <Message Text="SUCCESS!  Generated binaries and packages are dropped at $(CurrentDir)drop\$(Configuration)" Importance="High"/>
   </Target>
 
-  <Target Name="BuildAll" DependsOnTargets="RestorePackagesProd;RestorePackagesTest;BuildProd;BuildTest;CopyProdBinaries;GenerateNugetPackages">
+  <Target Name="BuildAll" DependsOnTargets="RestorePackagesProd;BuildProd;CopyProdBinaries;GenerateNugetPackages">
     <Message Text="SUCCESS!  Generated binaries and packages are dropped at $(CurrentDir)drop\$(Configuration)" Importance="High"/>
   </Target>
 
   <!-- Builds code, this target doesn't generates nuget packages. -->
-  <Target Name="BuildCode" DependsOnTargets="RestorePackagesProd;RestorePackagesTest;CleanAll;BuildProd;BuildTest;CopyProdBinaries">
+  <Target Name="BuildCode" DependsOnTargets="RestorePackagesProd;CleanAll;BuildProd;CopyProdBinaries">
     <Message Text="SUCCESS!  Generated binaries are dropped at $(CurrentDir)drop\$(Configuration)" Importance="High"/>
   </Target>
 
@@ -77,7 +77,7 @@
     <RemoveDir Directories="$(CurrentDir)\drop"/>
     
     <Message Text="Cleaning all projects ..."/>
-    <CallTarget Targets="CleanProd;CleanTest" />
+    <CallTarget Targets="CleanProd" />
   </Target>
   
   <Target Name="CleanProd">

--- a/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{1BDC4681-FDBA-4E55-A247-5F779627A4D7}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Actors.StateMigration.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.StateMigration.Tests/Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{1BDC4681-FDBA-4E55-A247-5F779627A4D7}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Actors.StateMigration.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{63B58D31-66BB-4879-B4F1-0969FA3F4464}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Actors.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{63B58D31-66BB-4879-B4F1-0969FA3F4464}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Actors.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
@@ -22,7 +22,8 @@
     <ProjectReference Include="$(RepoRoot)src\netstandard\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <!-- BinarryFormatter compatibility package -->
+    <!-- BinaryFormatter compatibility package -->
+    <!-- The need for this package is documented in https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-migration-guide/compatibility-package-->
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0-*" />
   </ItemGroup>
 </Project>

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests.csproj
@@ -5,7 +5,8 @@
     <ProjectGuid>{AE4034AC-27BC-43B8-9176-068B4794E25E}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Services.Remoting.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-   <TargetFramework>net6.0</TargetFramework>
+   <TargetFramework>net9.0</TargetFramework>
+   <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
@@ -19,5 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\netstandard\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting_netstandard.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- BinarryFormatter compatibility package -->
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0-*" />
   </ItemGroup>
 </Project>

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{ECB3825D-B309-4C76-A20D-76544459F611}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Services.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/Microsoft.ServiceFabric.Services.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{ECB3825D-B309-4C76-A20D-76544459F611}</ProjectGuid>
     <AssemblyName>Microsoft.ServiceFabric.Services.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />


### PR DESCRIPTION
This PR enables tests for .NET 9 builds. 

Compatibility with the deprecated BinaryFormatter has been introduced so that .NET 9 tests can be enabled.

Additionally, we are moving away from the `buils.ps1` script, which uses `msbuild` under the hood. Instead, we are moving to the `dotnet` tool, in the aim of streamlining the build process and infrastructure. 

Internal ADO work item: https://dev.azure.com/msazure/One/_workitems/edit/29603235