### PR TITLE
Switch to MIT license for NuGet packages

### DIFF
--- a/properties/service_fabric_nuget.props
+++ b/properties/service_fabric_nuget.props
@@ -11,7 +11,7 @@
     <Authors>Microsoft</Authors>
     <Owners>Microsoft,ServiceFabric</Owners>
     <ProjectUrl>http://aka.ms/servicefabric</ProjectUrl>
-    <LicenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</LicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RequireLicenseAcceptance>True</RequireLicenseAcceptance>
     <NoNuspecTags>true</NoNuspecTags>

--- a/properties/service_fabric_nuget.props
+++ b/properties/service_fabric_nuget.props
@@ -13,7 +13,6 @@
     <ProjectUrl>http://aka.ms/servicefabric</ProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <RequireLicenseAcceptance>True</RequireLicenseAcceptance>
     <NoNuspecTags>true</NoNuspecTags>
     <Tags>ServiceFabric Microsoft Azure Fabric</Tags>
     <IconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</IconUrl>


### PR DESCRIPTION
## Changes

* Switch to MIT license for NuGet packages

## Details

There seems to be a disconnect between the license specified on NuGet packages and the actual [license](https://github.com/microsoft/service-fabric-services-and-actors-dotnet/blob/develop/LICENSE.txt#L7) used by the code.

We are using these packages in [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/70ed217a9bcf0a94b59e0a90a4fa328710299770/src/OpenTelemetry.Instrumentation.ServiceFabricRemoting/OpenTelemetry.Instrumentation.ServiceFabricRemoting.csproj#L29-L30) and the recently introduced [FOSSA](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2566) scanning is reporting this as an issue.

/cc @kielek @rajkumar-rangaraj