### PR TITLE
Fix unexpected Remoting V1 deprecation errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,9 @@ jobs:
       TEST_RESULT_DIR: drop\testresults
     steps:
       - uses: actions/checkout@v1
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0.x'
+      - name: Disable strong name verification for testing
+        shell: powershell
+        run: .\SkipStrongName.ps1
       - name: Build Everything
         shell: powershell
         run: dotnet build buildAll.proj

--- a/code.sln
+++ b/code.sln
@@ -54,6 +54,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netfx", "netfx", "{02EA681E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ServiceFabric.Actors.Tests_netfx", "test\netfx\Microsoft.ServiceFabric.Actors.Tests\Microsoft.ServiceFabric.Actors.Tests_netfx.csproj", "{A5D7C812-6B48-71FD-CACC-C65326E24AC0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ServiceFabric.Services.Remoting.Tests_netfx", "test\netfx\Microsoft.ServiceFabric.Services.Remoting.Tests\Microsoft.ServiceFabric.Services.Remoting.Tests_netfx.csproj", "{9DA198B2-2C88-432F-87A4-1962225A154B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -198,6 +200,14 @@ Global
 		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|x64.ActiveCfg = Release|Any CPU
 		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|x64.Build.0 = Release|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DA198B2-2C88-432F-87A4-1962225A154B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -224,6 +234,7 @@ Global
 		{1BDC4681-FDBA-4E55-A247-5F779627A4D7} = {BB93122C-21C5-4BB8-B385-74FC423D6027}
 		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {DEC12940-3D38-4526-9157-27CB8BD23D3D}
 		{A5D7C812-6B48-71FD-CACC-C65326E24AC0} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{9DA198B2-2C88-432F-87A4-1962225A154B} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8CC7D7F7-CBD9-428B-A190-7A4D56C920FE}

--- a/code.sln
+++ b/code.sln
@@ -50,6 +50,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ServiceFabric.Act
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ServiceFabric.Actors.StateMigration.Tests", "test\unittests\Microsoft.ServiceFabric.Actors.StateMigration.Tests\Microsoft.ServiceFabric.Actors.StateMigration.Tests.csproj", "{1BDC4681-FDBA-4E55-A247-5F779627A4D7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netfx", "netfx", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ServiceFabric.Actors.Tests_netfx", "test\netfx\Microsoft.ServiceFabric.Actors.Tests\Microsoft.ServiceFabric.Actors.Tests_netfx.csproj", "{A5D7C812-6B48-71FD-CACC-C65326E24AC0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -186,6 +190,14 @@ Global
 		{1BDC4681-FDBA-4E55-A247-5F779627A4D7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1BDC4681-FDBA-4E55-A247-5F779627A4D7}.Release|x64.ActiveCfg = Release|x64
 		{1BDC4681-FDBA-4E55-A247-5F779627A4D7}.Release|x64.Build.0 = Release|x64
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Debug|x64.Build.0 = Debug|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|x64.ActiveCfg = Release|Any CPU
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -210,6 +222,8 @@ Global
 		{B5E3B9D7-E91E-4B76-959D-D418E973FCAF} = {861D6F40-D3CE-46CF-B8AD-0215B9F38BE1}
 		{E5B52C61-66BE-4D71-88D2-E50F78011C72} = {8B80B63B-5107-4845-9F19-647CFA7911A3}
 		{1BDC4681-FDBA-4E55-A247-5F779627A4D7} = {BB93122C-21C5-4BB8-B385-74FC423D6027}
+		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {DEC12940-3D38-4526-9157-27CB8BD23D3D}
+		{A5D7C812-6B48-71FD-CACC-C65326E24AC0} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8CC7D7F7-CBD9-428B-A190-7A4D56C920FE}

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>11</BuildVersion>
+    <BuildVersion>12</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/FabActUtil/Microsoft.ServiceFabric.Actors.targets
+++ b/src/FabActUtil/Microsoft.ServiceFabric.Actors.targets
@@ -4,10 +4,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="FabActUtilGenerateManifestVS2013" AfterTargets="Build" Condition="'$(RunFabActUtil)' == 'true' and '$(VS2013ServiceFabricActorBuild)' == 'true'">
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)FabActUtil.exe&quot; /out:&quot;$(PackageRoot)&quot; /t:manifest /ap:$(ApplicationPrefix) /sp:$(ServicePackagePrefix) /in:&quot;$(OutDir)$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)&quot; (FabActUtilAdditionalArguments)" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)FabActUtil.exe&quot; /out:&quot;$(PackageRoot)&quot; /t:manifest /ap:$(ApplicationPrefix) /sp:$(ServicePackagePrefix) /in:&quot;$(OutDir)$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)&quot; (FabActUtilAdditionalArguments)"
+      WorkingDirectory="$(MSBuildProjectDirectory)" LogStandardErrorAsError="true" />
   </Target>
   <Target Name="FabActUtilGenerateScriptVS2013" AfterTargets="FabActUtilGenerateManifestVS2013" Condition="'$(RunFabActUtil)' == 'true' and '$(VS2013ServiceFabricActorBuild)' == 'true'">
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)FabActUtil.exe&quot; /out:&quot;$(PackageRoot)\..&quot; /t:script /ap:$(ApplicationPrefix) /sp:$(ServicePackagePrefix) /in:&quot;$(OutDir)$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)\&quot; $(FabActUtilAdditionalArguments)" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)FabActUtil.exe&quot; /out:&quot;$(PackageRoot)\..&quot; /t:script /ap:$(ApplicationPrefix) /sp:$(ServicePackagePrefix) /in:&quot;$(OutDir)$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)\&quot; $(FabActUtilAdditionalArguments)"
+      WorkingDirectory="$(MSBuildProjectDirectory)" LogStandardErrorAsError="true" />
   </Target>
   <Target Name="FabActUtilCopyCodeVS2013" AfterTargets="FabActUtilGenerateScriptVS2013" Condition="'$(RunFabActUtil)' == 'true' and '$(VS2013ServiceFabricActorBuild)' == 'true'">
     <RemoveDir Directories="$(ServicePackagePath)\Code" />
@@ -18,7 +20,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </Target>
 
   <Target Name="_UpdateServiceFabricServiceManifest"  AfterTargets="Build" Condition=" '$(UpdateServiceFabricManifestEnabled)' == 'true' and '$(VS2013ServiceFabricActorBuild)' != 'true' ">
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)\FabActUtil.exe&quot; /spp:&quot;$(ServicePackagePath)&quot; /t:manifest /sp:&quot;$(ServicePackagePrefix)&quot; /in:&quot;$(OutDir)\$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)\&quot; $(FabActUtilAdditionalArguments)" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)\FabActUtil.exe&quot; /spp:&quot;$(ServicePackagePath)&quot; /t:manifest /sp:&quot;$(ServicePackagePrefix)&quot; /in:&quot;$(OutDir)\$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)\&quot; $(FabActUtilAdditionalArguments)"
+      WorkingDirectory="$(MSBuildProjectDirectory)" LogStandardErrorAsError="true" />
   </Target>
   <Target Name="_UpdateServiceFabricApplicationManifest" Condition=" '$(UpdateServiceFabricManifestEnabled)' == 'true' and '$(VS2013ServiceFabricActorBuild)' != 'true' ">
     <PropertyGroup>
@@ -28,6 +31,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Local1NodeStartupServiceParamFileArg Condition=" '$(Local1NodeStartupServiceParamFile)' != '' ">/local1nodestartupserviceparamfile:&quot;$(Local1NodeStartupServiceParamFile)&quot;</Local1NodeStartupServiceParamFileArg>
       <StartupServicesFilePathArg Condition=" '$(StartupServicesFilePath)' != '' ">/ssfp:&quot;$(StartupServicesFilePath)&quot;</StartupServicesFilePathArg>
     </PropertyGroup>
-    <Exec Command="&quot;$(MSBuildThisFileDirectory)\FabActUtil.exe&quot; /app:&quot;$(ApplicationPackagePath)&quot; /spp:&quot;$(ServicePackagePath)&quot; /t:manifest /ap:&quot;$(ApplicationPrefix)&quot; /sp:&quot;$(ServicePackagePrefix)&quot; /in:&quot;$(OutDir)\$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)\&quot; $(StartupServicesFilePathArg) $(Local5NodeAppParamFileArg) $(Local1NodeAppParamFileArg) $(Local5NodeStartupServiceParamFileArg) $(Local1NodeStartupServiceParamFileArg) $(FabActUtilAdditionalArguments)" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="&quot;$(MSBuildThisFileDirectory)\FabActUtil.exe&quot; /app:&quot;$(ApplicationPackagePath)&quot; /spp:&quot;$(ServicePackagePath)&quot; /t:manifest /ap:&quot;$(ApplicationPrefix)&quot; /sp:&quot;$(ServicePackagePrefix)&quot; /in:&quot;$(OutDir)\$(AssemblyName).$(OutputType)&quot; /arp:&quot;$(TargetDir)\&quot; $(StartupServicesFilePathArg) $(Local5NodeAppParamFileArg) $(Local1NodeAppParamFileArg) $(Local5NodeStartupServiceParamFileArg) $(Local1NodeStartupServiceParamFileArg) $(FabActUtilAdditionalArguments)"
+      WorkingDirectory="$(MSBuildProjectDirectory)" LogStandardErrorAsError="true" />
   </Target>
 </Project>

--- a/src/FabActUtil/Program.cs
+++ b/src/FabActUtil/Program.cs
@@ -33,7 +33,8 @@ namespace FabActUtil
             }
             catch (Exception e)
             {
-                Console.Error.WriteLine(e);
+                Console.Error.WriteLine(e.Message);
+                Console.WriteLine(e);
                 return -1;
             }
 

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/ActorRemotingProviderAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/ActorRemotingProviderAttribute.cs
@@ -151,7 +151,10 @@ namespace Microsoft.ServiceFabric.Actors.Remoting
 #if DotNetCoreClr
             return new FabricTransportActorRemotingProviderAttribute();
 #else
-            var exception = new InvalidOperationException("To use Actor Remoting, the version of the remoting stack must be specified explicitely.");
+            var exception = new InvalidOperationException(
+                "Version 1 of the remoting protocol has been deprecated and will be removed in the next major version of Service Fabric. " +
+                "Please add an ActorRemotingProviderAttribute to the service assembly to specify the remoting stack you want to use. " +
+                "Note that remoting protocol version 2.1 is now used by default and version 1 must be enabled explicitly.");
             exception.HelpLink = "https://github.com/microsoft/service-fabric/blob/master/release_notes/Deprecated/RemotingV1.md";
             throw exception;
 #endif

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/ActorRemotingProviderAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/ActorRemotingProviderAttribute.cs
@@ -7,16 +7,15 @@ namespace Microsoft.ServiceFabric.Actors.Remoting
 {
     using System;
     using System.Collections.Generic;
-    using System.Fabric;
     using System.Reflection;
     using Microsoft.ServiceFabric.Actors.Client;
-    using Microsoft.ServiceFabric.Actors.Remoting.FabricTransport;
     using Microsoft.ServiceFabric.Actors.Runtime;
-    using Microsoft.ServiceFabric.Services.Communication.Runtime;
     using Microsoft.ServiceFabric.Services.Remoting;
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
 
-#if !DotNetCoreClr
+#if DotNetCoreClr
+    using Microsoft.ServiceFabric.Actors.Remoting.FabricTransport;
+#else
     using Microsoft.ServiceFabric.Services.Remoting.V1;
     using Microsoft.ServiceFabric.Services.Remoting.V1.Client;
 #endif
@@ -149,9 +148,13 @@ namespace Microsoft.ServiceFabric.Actors.Remoting
                 }
             }
 
-            InvalidOperationException exception = new InvalidOperationException("To use Actor Remoting, the version of the remoting stack must be specified explicitely.");
+#if DotNetCoreClr
+            return new FabricTransportActorRemotingProviderAttribute();
+#else
+            var exception = new InvalidOperationException("To use Actor Remoting, the version of the remoting stack must be specified explicitely.");
             exception.HelpLink = "https://github.com/microsoft/service-fabric/blob/master/release_notes/Deprecated/RemotingV1.md";
             throw exception;
+#endif
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.Services.Remoting/ServiceRemotingProviderAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/ServiceRemotingProviderAttribute.cs
@@ -6,13 +6,13 @@
 namespace Microsoft.ServiceFabric.Services.Remoting
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Fabric;
     using System.Reflection;
-    using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
     using Microsoft.ServiceFabric.Services.Remoting.Runtime;
-#if !DotNetCoreClr
+#if DotNetCoreClr
+    using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
+#else
     using Microsoft.ServiceFabric.Services.Remoting.V1.Client;
 #endif
 
@@ -146,9 +146,13 @@ namespace Microsoft.ServiceFabric.Services.Remoting
                 }
             }
 
-            InvalidOperationException exception = new InvalidOperationException("To use Service Remoting, the version of the remoting stack must be specified explicitely.");
+#if DotNetCoreClr
+            return new FabricTransportServiceRemotingProviderAttribute();
+#else
+            var exception = new InvalidOperationException("To use Service Remoting, the version of the remoting stack must be specified explicitely.");
             exception.HelpLink = "https://github.com/microsoft/service-fabric/blob/master/release_notes/Deprecated/RemotingV1.md";
             throw exception;
+#endif
         }
     }
 }

--- a/src/Microsoft.ServiceFabric.Services.Remoting/ServiceRemotingProviderAttribute.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/ServiceRemotingProviderAttribute.cs
@@ -149,7 +149,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting
 #if DotNetCoreClr
             return new FabricTransportServiceRemotingProviderAttribute();
 #else
-            var exception = new InvalidOperationException("To use Service Remoting, the version of the remoting stack must be specified explicitely.");
+            var exception = new InvalidOperationException(
+                "Version 1 of the remoting protocol has been deprecated and will be removed in the next major version of Service Fabric. " +
+                "Please add a ServiceRemotingProviderAttribute to the service assembly to specify the remoting stack you want to use. " +
+                "Note that remoting protocol version 2.1 is now used by default and version 1 must be enabled explicitly.");
             exception.HelpLink = "https://github.com/microsoft/service-fabric/blob/master/release_notes/Deprecated/RemotingV1.md";
             throw exception;
 #endif

--- a/test/netfx/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests_netfx.csproj
+++ b/test/netfx/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests_netfx.csproj
@@ -9,13 +9,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Inspector" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(RepoRoot)test\unittests\Microsoft.ServiceFabric.Actors.Tests\ActorRemotingProviderAttributeTest.cs" />

--- a/test/netfx/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests_netfx.csproj
+++ b/test/netfx/Microsoft.ServiceFabric.Actors.Tests/Microsoft.ServiceFabric.Actors.Tests_netfx.csproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\properties\service_fabric_managed_netframework.props" />
+  <PropertyGroup>
+    <ProjectGuid>{A5D7C812-6B48-71FD-CACC-C65326E24AC0}</ProjectGuid>
+    <AssemblyName>Microsoft.ServiceFabric.Actors.Tests</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Inspector" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)test\unittests\Microsoft.ServiceFabric.Actors.Tests\ActorRemotingProviderAttributeTest.cs" />
+    <Compile Include="$(RepoRoot)test\unittests\Microsoft.ServiceFabric.Actors.Tests\AssemblyAttributes.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Microsoft.ServiceFabric.Actors\Microsoft.ServiceFabric.Actors.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/netfx/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests_netfx.csproj
+++ b/test/netfx/Microsoft.ServiceFabric.Services.Remoting.Tests/Microsoft.ServiceFabric.Services.Remoting.Tests_netfx.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\properties\service_fabric_managed_netframework.props" />
+ <PropertyGroup>
+    <ProjectGuid>{9DA198B2-2C88-432F-87A4-1962225A154B}</ProjectGuid>
+    <AssemblyName>Microsoft.ServiceFabric.Services.Remoting.Tests</AssemblyName>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="inspector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)test\unittests\Microsoft.ServiceFabric.Services.Remoting.Tests\ServiceRemotingProviderAttributeTest.cs" />
+    <Compile Include="$(RepoRoot)test\unittests\Microsoft.ServiceFabric.Services.Remoting.Tests\AssemblyAttributes.cs" />
+  </ItemGroup>
+</Project>

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/ActorRemotingProviderAttributeTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/ActorRemotingProviderAttributeTest.cs
@@ -26,7 +26,9 @@ namespace Microsoft.ServiceFabric.Actors.Tests
 
 #if NETFRAMEWORK
             private readonly string expectedExceptionMessagesForMissingRemotingProviderAttribute =
-                "To use Actor Remoting, the version of the remoting stack must be specified explicitely.";
+                "Version 1 of the remoting protocol has been deprecated and will be removed in the next major version of Service Fabric. " +
+                "Please add an ActorRemotingProviderAttribute to the service assembly to specify the remoting stack you want to use. " +
+                "Note that remoting protocol version 2.1 is now used by default and version 1 must be enabled explicitly.";
 #endif
 
             private readonly ActorRemotingProviderAttribute expectedRemotingProvider =

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/AssemblyAttributes.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/AssemblyAttributes.cs
@@ -2,10 +2,6 @@ using Microsoft.ServiceFabric.Services.Remoting;
 using Microsoft.ServiceFabric.Actors.Remoting.FabricTransport;
 using Xunit;
 
-// This sets FabricTransportActorRemotingProvider as the default remoting provider for the whole Microsoft.ServiceFabric.Actors.Test project.
-// This is neccessary as not setting a remoting provider explicitly will raise an exception.
-[assembly: FabricTransportActorRemotingProvider(RemotingClientVersion=RemotingClientVersion.V2_1, RemotingListenerVersion=RemotingListenerVersion.V2_1)]
-
 // This attribute is used to run tests in the same assembly in sequence.
 // It is necessary for ActorRemotingProviderAttributeTest suit to run properly,
 // because ActorRemotingProviderAtrribut has static state and cannot be teste in parallel.

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/ServiceRemotingProviderAttributeTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/ServiceRemotingProviderAttributeTest.cs
@@ -26,7 +26,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
 
 #if NETFRAMEWORK
             private readonly string expectedExceptionMessagesForMissingRemotingProviderAttribute =
-                "To use Service Remoting, the version of the remoting stack must be specified explicitely.";
+                "Version 1 of the remoting protocol has been deprecated and will be removed in the next major version of Service Fabric. " +
+                "Please add a ServiceRemotingProviderAttribute to the service assembly to specify the remoting stack you want to use. " +
+                "Note that remoting protocol version 2.1 is now used by default and version 1 must be enabled explicitly.";
 #endif
 
             private readonly ServiceRemotingProviderAttribute expectedRemotingProvider =

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/ServiceRemotingProviderAttributeTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/ServiceRemotingProviderAttributeTest.cs
@@ -21,27 +21,25 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
 
         public class GetProvider : ServiceRemotingProviderAttributeTest, IDisposable
         {
-            protected readonly Mock<Assembly> mockAssemblyWithoutRemotingProviderAttribute = new Mock<Assembly>();
-            protected readonly Mock<Assembly> mockAssemblyWithRemotingProviderAttribute = new Mock<Assembly>();
+            protected readonly Assembly mockAssemblyWithoutRemotingProviderAttribute = MockAssembly();
+            protected readonly Assembly mockAssemblyWithRemotingProviderAttribute;
 
+#if NETFRAMEWORK
             private readonly string expectedExceptionMessagesForMissingRemotingProviderAttribute =
                 "To use Service Remoting, the version of the remoting stack must be specified explicitely.";
+#endif
 
-            private readonly FabricTransportServiceRemotingProviderAttribute expectedRemotingProvider =
+            private readonly ServiceRemotingProviderAttribute expectedRemotingProvider =
                 new FabricTransportServiceRemotingProviderAttribute();
 
             public GetProvider()
             {
-                this.mockAssemblyWithoutRemotingProviderAttribute
-                    .Setup(assembly => assembly.GetCustomAttributes(It.IsAny<Type>(), It.IsAny<bool>()))
-                    .Returns(new Attribute[0]);
-                this.mockAssemblyWithRemotingProviderAttribute
-                    .Setup(assembly => assembly.GetCustomAttributes(It.IsAny<Type>(), It.IsAny<bool>()))
-                    .Returns(new Attribute[] { this.expectedRemotingProvider });
+                this.mockAssemblyWithRemotingProviderAttribute = MockAssembly(this.expectedRemotingProvider);
             }
 
             public class WithNullArgument : GetProvider 
             {
+#if NETFRAMEWORK
                 [Fact]
                 public void ThrowsExceptionWhenEntryAssemblyIsUnmanagedAssembly()
                 {
@@ -56,18 +54,19 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
                 [Fact]
                 public void ThrowsExcpetionWhenEntryAssemblyDoesNotHaveProviderAttribute()
                 {
-                    typeof(ServiceRemotingProviderAttribute).Field<Assembly>().Set(this.mockAssemblyWithoutRemotingProviderAttribute.Object);
+                    typeof(ServiceRemotingProviderAttribute).Field<Assembly>().Set(this.mockAssemblyWithoutRemotingProviderAttribute);
 
                     var exception = Assert.Throws<InvalidOperationException>(
                         () => ServiceRemotingProviderAttribute.GetProvider());
 
                     Assert.Equal(this.expectedExceptionMessagesForMissingRemotingProviderAttribute, exception.Message);
                 }
+#endif
 
                 [Fact]
                 public void ReturnsRemotingProviderAttributeOfEntryAssembly()
                 {
-                    typeof(ServiceRemotingProviderAttribute).Field<Assembly>().Set(this.mockAssemblyWithRemotingProviderAttribute.Object);
+                    typeof(ServiceRemotingProviderAttribute).Field<Assembly>().Set(this.mockAssemblyWithRemotingProviderAttribute);
 
                     ServiceRemotingProviderAttribute provider = ServiceRemotingProviderAttribute.GetProvider();
 
@@ -77,23 +76,20 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
 
             public class WithTypeArrayArgument : GetProvider 
             {
-                readonly Mock<Type> mockTypeWithRemotingProviderAssemblyAttribute = new Mock<Type>();
-                readonly Mock<Type> mockTypeWithoutRemotingProviderAssemblyAttribute = new Mock<Type>();
+                readonly Type mockTypeWithRemotingProviderAssemblyAttribute;
+                readonly Type mockTypeWithoutRemotingProviderAssemblyAttribute;
 
                 public WithTypeArrayArgument()
                 {
-                    this.mockTypeWithRemotingProviderAssemblyAttribute
-                        .Setup(type => type.Assembly)
-                        .Returns(this.mockAssemblyWithRemotingProviderAttribute.Object);
-                    this.mockTypeWithoutRemotingProviderAssemblyAttribute
-                        .Setup(type => type.Assembly)
-                        .Returns(this.mockAssemblyWithoutRemotingProviderAttribute.Object);
+                    this.mockTypeWithRemotingProviderAssemblyAttribute = MockType(this.mockAssemblyWithRemotingProviderAttribute);
+                    this.mockTypeWithoutRemotingProviderAssemblyAttribute = MockType(this.mockAssemblyWithoutRemotingProviderAttribute);
                 }
 
+#if NETFRAMEWORK
                 [Fact]
                 public void ThrowsExceptionWhenTypeHasNoAssemblyProviderAttribute()
                 {
-                    var types = new Type[] { this.mockTypeWithoutRemotingProviderAssemblyAttribute.Object };
+                    var types = new Type[] { this.mockTypeWithoutRemotingProviderAssemblyAttribute };
                     typeof(ServiceRemotingProviderAttribute).Field<Assembly>().Set(null);
 
                     var exception = Assert.Throws<InvalidOperationException>(
@@ -101,13 +97,25 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
 
                     Assert.Equal(this.expectedExceptionMessagesForMissingRemotingProviderAttribute, exception.Message);
                 }
+#else
+                [Fact]
+                public void ReturnsDefaultFabricTransportServiceRemotingProviderWhenTypeHasNoAssemblyProviderAttribute()
+                {
+                    var result = ServiceRemotingProviderAttribute.GetProvider(new[] { this.mockTypeWithoutRemotingProviderAssemblyAttribute });
+
+                    var expected = new FabricTransportServiceRemotingProviderAttribute();
+                    var actual = Assert.IsType<FabricTransportServiceRemotingProviderAttribute>(result);
+                    Assert.Equal(expected.RemotingClientVersion, actual.RemotingClientVersion);
+                    Assert.Equal(expected.RemotingListenerVersion, actual.RemotingListenerVersion);
+                }
+#endif
 
                 [Fact]
                 public void ReturnsRemotingProviderAttributeOfTypeAssembly()
                 {
-                    var types = new Type[] { this.mockTypeWithRemotingProviderAssemblyAttribute.Object };
+                    var types = new Type[] { this.mockTypeWithRemotingProviderAssemblyAttribute };
 
-                    ServiceRemotingProviderAttribute provider = ServiceRemotingProviderAttribute.GetProvider(types);;
+                    var provider = ServiceRemotingProviderAttribute.GetProvider(types);;
 
                     Assert.Same(this.expectedRemotingProvider, provider);
                 }
@@ -117,6 +125,37 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests
             {
                 typeof(ServiceRemotingProviderAttribute).Field<Assembly>().Set(Assembly.GetEntryAssembly());
             }
+
+            static Assembly MockAssembly(ServiceRemotingProviderAttribute provider = null)
+            {
+                var assembly = new Mock<TestAssembly>();
+                Attribute[] attributes = provider == null ? new Attribute[0] : new[] { provider };
+                assembly.Setup(_ => _.GetCustomAttributes(typeof(ServiceRemotingProviderAttribute), It.IsAny<bool>())).Returns(attributes);
+                return assembly.Object;
+            }
+
+            static Type MockType(Assembly assembly)
+            {
+                var type = new Mock<Type>();
+                type.Setup(_ => _.Assembly).Returns(assembly);
+#if NETFRAMEWORK
+                var reflectableType = type.As<IReflectableType>();
+                reflectableType.Setup(_ => _.GetTypeInfo()).Returns(MockTypeInfo(assembly));
+#endif
+                return type.Object;
+            }
+
+#if NETFRAMEWORK
+            static TypeInfo MockTypeInfo(Assembly assembly)
+            {
+                var typeInfo = new Mock<TypeDelegator>();
+                typeInfo.Setup(_ => _.Assembly).Returns(assembly);
+                return typeInfo.Object;
+            }
+#endif
+
+            // Make Assembly concrete to enable mocking on NetFx
+            public class TestAssembly : Assembly { }
         }
     }
 }


### PR DESCRIPTION
- Restore original behavior of the `ActorRemotingProviderAttribute` and `ServiceRemotingProviderAttribute` on NetStandard so that explicitly specifying a redundant assembly attribute is not required. The attribute is now required only on NetFx.
- Create NetFx test projects with the minimum set of tests for now to verify new NetFx behavior.
- Make build.yml use pre-installed .NET 9 and disable strong name verification to enable testing of the delay-signed NetFx assemblies.
- Make remoting provider error messages more descriptive.
- Make FabActUtil report exception messages as build errors and stack trace as build messages.
- Increment build number for integration in WindowsFabric repo.