### PR TITLE
Fix version for Diagnostics dll

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -22,10 +22,14 @@
 
     <!-- Version for binaries, nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
-    <MajorVersion>9</MajorVersion>
+    <MajorVersion Condition="'$(MSBuildProjectName)' != 'Microsoft.ServiceFabric.Diagnostics'">9</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <BuildVersion>2</BuildVersion>
+    <BuildVersion>3</BuildVersion>
     <Revision>0</Revision>
+
+    <!-- Major Version for Microsoft.ServiceFabric.Diagnostics binary -->
+    <!-- We migrated Diagnostics package from WindowsFabric repo and we need to keep the versioning consistent -->
+    <MajorVersion Condition="'$(MSBuildProjectName)' == 'Microsoft.ServiceFabric.Diagnostics'">12</MajorVersion>
 
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Diagnostics/Microsoft.ServiceFabric.Diagnostics.csproj
+++ b/src/Microsoft.ServiceFabric.Diagnostics/Microsoft.ServiceFabric.Diagnostics.csproj
@@ -4,7 +4,9 @@
 
   <PropertyGroup>
       <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-      <AssemblyName>Microsoft.ServiceFabric.Diagnostics</AssemblyName>
+      <RootNamespace>Microsoft.ServiceFabric.Diagnostics</RootNamespace>
+      <RootNamespace>$(AssemblyName)</RootNamespace>
+      <AssemblyTitle>$(AssemblyName)</AssemblyTitle>
       <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
       <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
We had an issue with Microsoft.ServiceFabric.Diagnostics package version. 
It was generated as version 1.0.0.0, which would fail AsmSpy verification if imported into WindowsFabric repo.

It turns out version for this assembly was not generated properly, which this pull request addresses by modifying csproj of this project to be in line with other projects in this repo.

Furthermore, since this project is moved from WindowsFabric repo, where it had version 11.0.0.0 (same as SF version), we need to keep the versioning consistent, so this is addressed by using a conditional MajorVersion property - 12 for this project, 9 for all the rest.