### PR TITLE
Introduce changes needed for SF12 into release9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
     <!-- Sort packages by name to reduce merge conflicts -->
 
-    <!-- Versions of some transitive dependencies have been overwritten due the the fact that 
+    <!-- Versions of some transitive dependencies have been overwritten due the the fact that
     they have been marked as vulnerable.  -->
 
     <!-- Each time direct dependecies are updated, the transitive
@@ -23,18 +23,18 @@
         <PackageVersion Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.1.12" />
         <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.12" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageVersion Include="Microsoft.ServiceFabric" Version="11.0.1928" />
-        <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="8.0.1928" />
-        <PackageVersion Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="8.0.1928" />
-        <PackageVersion Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="8.0.1928" />
+        <PackageVersion Include="Microsoft.ServiceFabric" Version="12.0.0-dev.user-cburg-wi-32024996.1003" />
+        <PackageVersion Include="Microsoft.ServiceFabric.Data" Version="9.0.0-dev.user-cburg-wi-32024996.1003" />
+        <PackageVersion Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="9.0.0-dev.user-cburg-wi-32024996.1003" />
+        <PackageVersion Include="Microsoft.ServiceFabric.FabricTransport.Internal" Version="9.0.0-dev.user-cburg-wi-32024996.1003" />
         <PackageVersion Include="Moq" Version="4.20.70" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" /> <!-- Transitive dependency -->
         <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
         <PackageVersion Include="System.Drawing.Common" Version="8.0.8" /> <!-- Transitive dependency -->
         <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" /> <!-- Transitive dependency -->
         <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
-        <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" /> 
-        <PackageVersion Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" /> 
+        <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
+        <PackageVersion Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
         <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="9.0.0" />
         <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.1" /> <!-- Transitive dependency -->
         <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" /> <!-- Transitive dependency -->
@@ -42,4 +42,4 @@
         <PackageVersion Include="xunit" Version="2.8.1" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
     </ItemGroup>
-  </Project> 
+  </Project>

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -23,7 +23,7 @@
     <!-- Version for binaries, nuget packages generated from this repo. -->
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>9</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MinorVersion>2</MinorVersion>
     <BuildVersion>0</BuildVersion>
     <Revision>0</Revision>
 


### PR DESCRIPTION
We need these changes in order to move ServiceFabric project to new major version (12). We also need to bump the package version to 9.2.0. in order to build the new nuget package.