### PR TITLE
Fix trace printout in FabricTransportRemotingListenerSettings

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>9</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <BuildVersion>0</BuildVersion>
+    <BuildVersion>1</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/Runtime/FabricTransportRemotingListenerSettings.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/Runtime/FabricTransportRemotingListenerSettings.cs
@@ -275,7 +275,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime
 
             AppTrace.TraceSource.WriteInfo(
                 Tracetype,
-                "MaxMessageSize: {0} , MaxConcurrentCalls: {1} , MaxQueueSize: {2} , OperationTimeoutInSeconds: {3} KeepAliveTimeoutInSeconds : {4} , SecurityCredentials {5} , HeaderBufferSize {6}," + "HeaderBufferCount {7} , ExceptionSerializationTechinique {8} , RemotingExceptionDepth {9}",
+                "MaxMessageSize: {0} , MaxConcurrentCalls: {1} , MaxQueueSize: {2} , OperationTimeoutInSeconds: {3} KeepAliveTimeoutInSeconds : {4} , SecurityCredentials {5} , HeaderBufferSize {6} , HeaderBufferCount {7} , RemotingExceptionDepth {8}",
                 settings.MaxMessageSize,
                 settings.MaxConcurrentCalls,
                 settings.MaxQueueSize,


### PR DESCRIPTION
Index in format string must not be larger than the size of the argument list.
String formatter throws exception here.

Bump version from 9.2.0 to 9.2.1.