### PR TITLE
Document GUIDs and manifests of the EventSource classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -49,11 +49,11 @@ end_of_line = crlf
 # Organize usings
 dotnet_sort_system_directives_first = true
 
-# Use this.
-dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_property = true:warning
-dotnet_style_qualification_for_method = true:warning
-dotnet_style_qualification_for_event = true:warning
+# Avoid this., reduce the code size and complexity to make it irrelevant instead
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
 
 # Use language keywords instead of BCL types
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorFrameworkEventSource.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ServiceFabric.Actors.Diagnostics
     // you must call the WriteEvent method on the base class, passing the event ID, followed by the same
     // arguments as the defined method is passed. Details at:
     // https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventattribute(v=vs.110).aspx
-    [EventSource(Name = "Microsoft-ServiceFabric-Actors", LocalizationResources = "Microsoft.ServiceFabric.Actors.SR")]
+    [EventSource(Name = "Microsoft-ServiceFabric-Actors", LocalizationResources = "Microsoft.ServiceFabric.Actors.SR", Guid = "0e1ec353-9f02-55d7-fbb8-f3857458acbd")]
     internal sealed class ActorFrameworkEventSource : EventSource
     {
         // Although the documentation claims it exists, EventKeywords.All does not

--- a/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
@@ -14,7 +14,7 @@ namespace Microsoft.ServiceFabric.Services.Runtime
     // you must call the WriteEvent method on the base class, passing the event ID, followed by the same
     // arguments as the defined method is passed. Details at:
     // https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventattribute(v=vs.110).aspx
-    [EventSource(Name = "Microsoft-ServiceFabric-Services", LocalizationResources = "Microsoft.ServiceFabric.Services.SR")]
+    [EventSource(Name = "Microsoft-ServiceFabric-Services", LocalizationResources = "Microsoft.ServiceFabric.Services.SR", Guid = "13c2a97d-71da-5ab5-47cb-1497aec602e1")]
     internal sealed class ServiceFrameworkEventSource : EventSource
     {
         internal static readonly ServiceFrameworkEventSource Writer = new ServiceFrameworkEventSource();

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/ActorEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/ActorEventSourceTest.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.Tracing;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ServiceFabric.Actors
+{
+    public abstract class ActorEventSourceTest
+    {
+        readonly ActorEventSource sut = ActorEventSource.Instance;
+
+        public sealed class Guid : ActorEventSourceTest
+        {
+            [Fact]
+            public void RemainsUnchangedForBackwardCompatibilityWithCollectionTools()
+            {
+                Assert.Equal(new System.Guid("e2f2656b-985e-5c5b-5ba3-bbe8a851e1d7"), sut.Guid);
+            }
+        }
+
+        public sealed class Manifest : ActorEventSourceTest
+        {
+            readonly ITestOutputHelper output;
+
+            public Manifest(ITestOutputHelper output) => this.output = output;
+
+            [Fact]
+            public void CanBeSavedForRegistrationWithExternalTools()
+            {
+                string manifest = EventSource.GenerateManifest(sut.GetType(), sut.GetType().Assembly.Location);
+                string manifestFile = Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(sut.GetType().Assembly.Location), sut.Name), "man");
+                File.WriteAllText(manifestFile, manifest);
+                output.WriteLine("To register generated manifest for ETL tools, run");
+                output.WriteLine($"sudo wevutil install-manifest {manifestFile}");
+            }
+        }
+    }
+}

--- a/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/ActorFrameworkEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Actors.Tests/Diagnostics/ActorFrameworkEventSourceTest.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.Tracing;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ServiceFabric.Actors.Diagnostics
+{
+    public abstract class ActorFrameworkEventSourceTest
+    {
+        readonly ActorFrameworkEventSource sut = new ActorFrameworkEventSource();
+
+        public sealed class Guid : ActorFrameworkEventSourceTest
+        {
+            [Fact]
+            public void RemainsUnchangedForBackwardCompatibilityWithCollectionTools()
+            {
+                Assert.Equal(new System.Guid("0e1ec353-9f02-55d7-fbb8-f3857458acbd"), sut.Guid);
+            }
+        }
+
+        public sealed class Manifest : ActorFrameworkEventSourceTest
+        {
+            readonly ITestOutputHelper output;
+
+            public Manifest(ITestOutputHelper output) => this.output = output;
+
+            [Fact]
+            public void CanBeSavedForRegistrationWithExternalTools()
+            {
+                string manifest = EventSource.GenerateManifest(sut.GetType(), sut.GetType().Assembly.Location);
+                string manifestFile = Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(sut.GetType().Assembly.Location), sut.Name), "man");
+                File.WriteAllText(manifestFile, manifest);
+                output.WriteLine("To register generated manifest for ETL tools, run");
+                output.WriteLine($"sudo wevutil install-manifest {manifestFile}");
+            }
+        }
+    }
+}

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/Runtime/ServiceFrameworkEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/Runtime/ServiceFrameworkEventSourceTest.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.Tracing;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ServiceFabric.Services.Runtime
+{
+    public abstract class ServiceFrameworkEventSourceTest
+    {
+        readonly ServiceFrameworkEventSource sut = new ServiceFrameworkEventSource();
+
+        public sealed class Guid : ServiceFrameworkEventSourceTest
+        {
+            [Fact]
+            public void RemainsUnchangedForBackwardCompatibilityWithCollectionTools()
+            {
+                Assert.Equal(new System.Guid("13c2a97d-71da-5ab5-47cb-1497aec602e1"), new ServiceFrameworkEventSource().Guid);
+            }
+        }
+
+        public sealed class Manifest : ServiceFrameworkEventSourceTest
+        {
+            readonly ITestOutputHelper output;
+
+            public Manifest(ITestOutputHelper output) => this.output = output;
+
+            [Fact]
+            public void CanBeSavedForRegistrationWithExternalTools()
+            {
+                string manifest = EventSource.GenerateManifest(sut.GetType(), sut.GetType().Assembly.Location);
+                string manifestFile = Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(sut.GetType().Assembly.Location), sut.Name), "man");
+                File.WriteAllText(manifestFile, manifest);
+                output.WriteLine("To register generated manifest for ETL tools, run");
+                output.WriteLine($"sudo wevutil install-manifest {manifestFile}");
+            }
+        }
+    }
+}

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceEventSourceTest.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.Tracing;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ServiceFabric.Services
+{
+    public abstract class ServiceEventSourceTest
+    {
+        readonly ServiceEventSource sut = ServiceEventSource.Instance;
+
+        public sealed class Guid : ServiceEventSourceTest
+        {
+            [Fact]
+            public void RemainsUnchangedForBackwardCompatibilityWithCollectionTools()
+            {
+                Assert.Equal(new System.Guid("27b7a543-7280-5c2a-b053-f2f798e2cbb7"), sut.Guid);
+            }
+        }
+
+        public sealed class Manifest : ServiceEventSourceTest
+        {
+            readonly ITestOutputHelper output;
+
+            public Manifest(ITestOutputHelper output) => this.output = output;
+
+            [Fact]
+            public void CanBeSavedForRegistrationWithExternalTools()
+            {
+                string manifest = EventSource.GenerateManifest(sut.GetType(), sut.GetType().Assembly.Location);
+                string manifestFile = Path.ChangeExtension(Path.Combine(Path.GetDirectoryName(sut.GetType().Assembly.Location), sut.Name), "man");
+                File.WriteAllText(manifestFile, manifest);
+                output.WriteLine("To register generated manifest for ETL tools, run");
+                output.WriteLine($"sudo wevutil install-manifest {manifestFile}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Create initial tests for the EventSource classes to document the dynamically-generated GUIDs in the code and save the instrumentation manifests for inspection and registration with the ETL tools, like Event Viewer and PerfView.