### PR TITLE
Make Actor and ServiceFrameworkEventSource classes inherit from ServiceFabricEventSource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - develop
+      - main
       - 'release_*'
     
   pull_request:
     branches: 
     - develop
+    - main
     - 'release_*'
 
 jobs:

--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>9</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <BuildVersion>3</BuildVersion>
+    <BuildVersion>4</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Diagnostics/ActorFrameworkEventSource.cs
@@ -3,19 +3,20 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+using System.Diagnostics.Tracing;
+using System.Fabric;
+using Microsoft.ServiceFabric.Diagnostics.Tracing;
+
 namespace Microsoft.ServiceFabric.Actors.Diagnostics
 {
-    using System;
-    using System.Diagnostics.Tracing;
-    using System.Fabric;
-
     // REMARKS:
     // When you apply EventAttribute attribute to an ETW event method defined on an EventSource-derived class,
     // you must call the WriteEvent method on the base class, passing the event ID, followed by the same
     // arguments as the defined method is passed. Details at:
     // https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventattribute(v=vs.110).aspx
     [EventSource(Name = "Microsoft-ServiceFabric-Actors", LocalizationResources = "Microsoft.ServiceFabric.Actors.SR")]
-    internal sealed class ActorFrameworkEventSource : EventSource
+    sealed class ActorFrameworkEventSource : ServiceFabricEventSource
     {
         // Although the documentation claims it exists, EventKeywords.All does not
         // seem to be defined in the assembly. So just use a constant with all possible

--- a/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Services/Runtime/ServiceFrameworkEventSource.cs
@@ -3,19 +3,20 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+using System.Diagnostics.Tracing;
+using System.Fabric;
+using Microsoft.ServiceFabric.Diagnostics.Tracing;
+
 namespace Microsoft.ServiceFabric.Services.Runtime
 {
-    using System;
-    using System.Diagnostics.Tracing;
-    using System.Fabric;
-
     // REMARKS:
     // When you apply EventAttribute attribute to an ETW event method defined on an EventSource-derived class,
     // you must call the WriteEvent method on the base class, passing the event ID, followed by the same
     // arguments as the defined method is passed. Details at:
     // https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventattribute(v=vs.110).aspx
     [EventSource(Name = "Microsoft-ServiceFabric-Services", LocalizationResources = "Microsoft.ServiceFabric.Services.SR")]
-    internal sealed class ServiceFrameworkEventSource : EventSource
+    sealed class ServiceFrameworkEventSource : ServiceFabricEventSource
     {
         internal static readonly ServiceFrameworkEventSource Writer = new ServiceFrameworkEventSource();
 


### PR DESCRIPTION
ServiceFabricEventSource traces are collected on Linux by the ServiceFabric telemetry infrastructure. The additional traces are needed to troubleshoot Azure Linux/Mariner test failures.

Also, increment SF.ActorsServices.Internal package version to 9.2.4.