### PR TITLE
Add new System and Fabric known exceptions (#418)

### DIFF
--- a/properties/service_fabric_common.props
+++ b/properties/service_fabric_common.props
@@ -24,7 +24,7 @@
     <!-- TODO: Versions numbers are changed here manually for now, Integrate this with GitVersion. -->
     <MajorVersion>9</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <BuildVersion>4</BuildVersion>
+    <BuildVersion>5</BuildVersion>
     <Revision>0</Revision>
 
   </PropertyGroup>

--- a/src/Microsoft.ServiceFabric.Actors/FabricActorExceptionKnownTypes.cs
+++ b/src/Microsoft.ServiceFabric.Actors/FabricActorExceptionKnownTypes.cs
@@ -3,15 +3,15 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Fabric;
+using Microsoft.ServiceFabric.Actors.Migration.Exceptions;
+using Microsoft.ServiceFabric.Actors.Runtime;
+using Microsoft.ServiceFabric.Services.Communication;
+
 namespace Microsoft.ServiceFabric.Actors
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Fabric;
-    using Microsoft.ServiceFabric.Actors.Migration.Exceptions;
-    using Microsoft.ServiceFabric.Actors.Runtime;
-    using Microsoft.ServiceFabric.Services.Communication;
-
     internal class FabricActorExceptionKnownTypes
     {
 #pragma warning disable SA1401 // Fields should be private

--- a/src/Microsoft.ServiceFabric.Actors/SR.Designer.cs
+++ b/src/Microsoft.ServiceFabric.Actors/SR.Designer.cs
@@ -674,7 +674,7 @@ namespace Microsoft.ServiceFabric.Actors {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Actor {0} can be decorated with atmost one Reentrancy attribute.
+        ///   Looks up a localized string similar to Actor {0} can be decorated with at most one Reentrancy attribute.
         /// </summary>
         internal static string InvalidReentrancyConfiguration {
             get {
@@ -683,7 +683,7 @@ namespace Microsoft.ServiceFabric.Actors {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A reentrant call has been made from actor while there are other outstanding actor calls. Atmost one reentrant call is allowed at a time..
+        ///   Looks up a localized string similar to A reentrant call has been made from actor while there are other outstanding actor calls. At most one reentrant call is allowed at a time..
         /// </summary>
         internal static string InvalidReentrantCall {
             get {

--- a/src/Microsoft.ServiceFabric.Actors/SR.resx
+++ b/src/Microsoft.ServiceFabric.Actors/SR.resx
@@ -184,7 +184,7 @@
     <value>Call context does not match current call context</value>
   </data>
   <data name="InvalidReentrancyConfiguration" xml:space="preserve">
-    <value>Actor {0} can be decorated with atmost one Reentrancy attribute</value>
+    <value>Actor {0} can be decorated with at most one Reentrancy attribute</value>
   </data>
   <data name="ReentrancyModeDisallowed" xml:space="preserve">
     <value>Actor {0} does not allow reentrant calls. ReentrancyMode must be set to LogicalCallContext to allow reentrant calls</value>
@@ -310,7 +310,7 @@
     <value>The actor state name '{0}' already exist.</value>
   </data>
   <data name="InvalidReentrantCall" xml:space="preserve">
-    <value>A reentrant call has been made from actor while there are other outstanding actor calls. Atmost one reentrant call is allowed at a time.</value>
+    <value>A reentrant call has been made from actor while there are other outstanding actor calls. At most one reentrant call is allowed at a time.</value>
   </data>
   <data name="TimerArgumentOutOfRange" xml:space="preserve">
     <value>TimeSpan TotalMilliseconds specified value must be between {0} and {1} </value>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/Runtime/FabricTransportRemotingListenerSettings.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/FabricTransport/Runtime/FabricTransportRemotingListenerSettings.cs
@@ -74,7 +74,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime
         /// This is used to obtain the port number on which to service will listen.
         /// </summary>
         /// <value>
-        /// EndpointResourceName is  name of the  endpoint resource defined in the service manifest.
+        /// EndpointResourceName is name of the  endpoint resource defined in the service manifest.
         /// </value>
         /// <remarks>
         /// Default value of EndpointResourceName  is "ServiceEndpoint" </remarks>
@@ -139,7 +139,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime
         /// Gets or sets the maxConcurrentCalls which represents maximum number of messages actively service processes at one time.
         /// </summary>
         /// <value>
-        /// MaxConcurrentCalls is  the upper limit of active messages in the service.
+        /// MaxConcurrentCalls is the upper limit of active messages in the service.
         /// </value>
         /// <remarks>
         /// Default value for the MaxConcurrentCalls is 0 which indicates that the setting is not enabled. This implies that all the messages are active and are processed simultaneously.

--- a/src/Microsoft.ServiceFabric.Services.Remoting/SR.resx
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/SR.resx
@@ -181,7 +181,7 @@
     <value>Detailed Remote Exception Information: {0}</value>
   </data>
   <data name="ErrorDeserializationFailure" xml:space="preserve">
-    <value>Failed to deserialize and get remote exception  {0}</value>
+    <value>Failed to deserialize and get remote exception {0}</value>
   </data>
   <data name="ErrorMethodNotSupportedInRemotingV1" xml:space="preserve">
     <value>Method '{0}' of interface '{1}' is not supported in remoting V1.</value>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricExceptionKnownTypes.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricExceptionKnownTypes.cs
@@ -3,14 +3,14 @@
 // Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Fabric;
+using Microsoft.ServiceFabric.Services.Communication;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
+
 namespace Microsoft.ServiceFabric.Services.Remoting.V2
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Fabric;
-    using Microsoft.ServiceFabric.Services.Communication;
-    using Microsoft.ServiceFabric.Services.Remoting.FabricTransport.Runtime;
-
     internal class FabricExceptionKnownTypes
     {
 #pragma warning disable SA1401 // Fields should be private
@@ -23,6 +23,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2
                     {
                         ToServiceExFunc = ex => ToServiceException(ex),
                         FromServiceExFunc = (svcEx, innerEx) => FromServiceException<FabricException>(svcEx, innerEx),
+                        InnerExFunc = ex => GetInnerExceptions(ex),
+                    }
+                },
+                {
+                    "System.Fabric.FabricInsufficientMaxLoadCapacityException", new ConvertorFuncs()
+                    {
+                        ToServiceExFunc = ex => ToServiceException(ex),
+                        FromServiceExFunc = (svcEx, innerEx) => FromServiceException<FabricInsufficientMaxLoadCapacityException>(svcEx, innerEx),
                         InnerExFunc = ex => GetInnerExceptions(ex),
                     }
                 },
@@ -91,6 +99,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2
                     }
                 },
                 {
+                    "System.Fabric.FabricSkipRestoreOperationException", new ConvertorFuncs()
+                    {
+                        ToServiceExFunc = ex => ToServiceException(ex),
+                        FromServiceExFunc = (svcEx, innerEx) => FromServiceException<FabricSkipRestoreOperationException>(svcEx, innerEx),
+                        InnerExFunc = ex => GetInnerExceptions(ex),
+                    }
+                },
+                {
                     "System.Fabric.FabricInvalidAddressException", new ConvertorFuncs()
                     {
                         ToServiceExFunc = ex => ToServiceException(ex),
@@ -143,6 +159,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2
                     {
                         ToServiceExFunc = ex => ToServiceException(ex),
                         FromServiceExFunc = (svcEx, innerEx) => FromServiceException<FabricBackupDirectoryNotEmptyException>(svcEx, innerEx),
+                        InnerExFunc = ex => GetInnerExceptions(ex),
+                    }
+                },
+                {
+                    "System.Fabric.FabricBackupNotFoundException", new ConvertorFuncs()
+                    {
+                        ToServiceExFunc = ex => ToServiceException(ex),
+                        FromServiceExFunc = (svcEx, innerEx) => FromServiceException<FabricBackupNotFoundException>(svcEx, innerEx),
                         InnerExFunc = ex => GetInnerExceptions(ex),
                     }
                 },
@@ -322,12 +346,15 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2
             {
                 args.Add(serviceException.Message);
             }
-            else if (typeof(T) == typeof(FabricMissingFullBackupException)
+            else if (typeof(T) == typeof(FabricInsufficientMaxLoadCapacityException)
+                || typeof(T) == typeof(FabricMissingFullBackupException)
                 || typeof(T) == typeof(FabricNotReadableException)
                 || typeof(T) == typeof(FabricBackupInProgressException)
                 || typeof(T) == typeof(FabricBackupDirectoryNotEmptyException)
+                || typeof(T) == typeof(FabricBackupNotFoundException)
                 || typeof(T) == typeof(FabricReplicationOperationTooLargeException)
                 || typeof(T) == typeof(FabricServiceNotFoundException)
+                || typeof(T) == typeof(FabricSkipRestoreOperationException)
                 || typeof(T) == typeof(FabricMessageTooLargeException)
                 || typeof(T) == typeof(FabricEndpointNotFoundException)
                 || typeof(T) == typeof(FabricDeleteBackupFileFailedException)

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/FabricTransport/Client/FabricTransportServiceRemotingClientFactory.cs
@@ -11,7 +11,6 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Client
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Services.Client;
-    using Microsoft.ServiceFabric.Services.Communication;
     using Microsoft.ServiceFabric.Services.Communication.Client;
     using Microsoft.ServiceFabric.Services.Remoting.Client;
     using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/Messaging/BufferPoolManager.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/Messaging/BufferPoolManager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2.Messaging
             this.allocator = new Allocator(segmentSize);
             ServiceTrace.Source.WriteInfo(
                 "BufferPoolManager",
-                "BufferMessageSize {0} ,BufferMacCount {1}",
+                "BufferMessageSize {0} ,BufferMaxCount {1}",
                 segmentSize,
                 bufferLimit);
         }

--- a/src/Microsoft.ServiceFabric.Services.Remoting/V2/SystemExceptionKnownTypes.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/V2/SystemExceptionKnownTypes.cs
@@ -11,12 +11,10 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2
     using System.Linq;
     using System.Reflection;
     using System.Resources;
-    using System.Runtime.CompilerServices;
-    using System.Runtime.ExceptionServices;
     using System.Runtime.InteropServices;
     using System.Runtime.Serialization;
     using System.Threading;
-    using System.Xml;
+    using System.Threading.Tasks;
     using Microsoft.ServiceFabric.Services.Communication;
 
     internal class SystemExceptionKnownTypes
@@ -385,6 +383,14 @@ namespace Microsoft.ServiceFabric.Services.Remoting.V2
                     {
                         ToServiceExFunc = ex => ToServiceException(ex),
                         FromServiceExFunc = (svcEx, innerEx) => FromServiceException<SynchronizationLockException>(svcEx, innerEx),
+                        InnerExFunc = ex => GetInnerExceptions(ex),
+                    }
+                },
+                {
+                    "System.Threading.Tasks.TaskCanceledException", new ConvertorFuncs()
+                    {
+                        ToServiceExFunc = ex => ToServiceException(ex),
+                        FromServiceExFunc = (svcEx, innerEx) => FromServiceException<TaskCanceledException>(svcEx, innerEx),
                         InnerExFunc = ex => GetInnerExceptions(ex),
                     }
                 },

--- a/src/Microsoft.ServiceFabric.Services/Communication/Runtime/ServiceReplicaListener.cs
+++ b/src/Microsoft.ServiceFabric.Services/Communication/Runtime/ServiceReplicaListener.cs
@@ -27,7 +27,7 @@ namespace Microsoft.ServiceFabric.Services.Communication.Runtime
         /// </summary>
         /// <param name="createCommunicationListener">Factory method for creating the communication listener</param>
         /// <param name="name">Name of the communication listener. This parameter is optional, if the service has only one communication listener</param>
-        /// <param name="listenOnSecondary">Specifies if the communication listener needs to be opened when the replica becomes Active secondary. THis parameter is optional</param>
+        /// <param name="listenOnSecondary">Specifies if the communication listener needs to be opened when the replica becomes Active secondary. This parameter is optional</param>
         public ServiceReplicaListener(
             Func<StatefulServiceContext, ICommunicationListener> createCommunicationListener,
             string name = DefaultName,

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/V2/ExceptionConvertors/FabricExceptionConvertorTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/V2/ExceptionConvertors/FabricExceptionConvertorTest.cs
@@ -80,6 +80,9 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.ExceptionConvertors
             new FabricPeriodicBackupNotEnabledException("FabricPeriodicBackupNotEnabledException"),
             new FabricValidationException("FabricValidationException"),
             new FabricTransportCallbackNotFoundException("FabricTransportCallbackNotFoundException"),
+            new FabricBackupNotFoundException("FabricBackupNotFoundException"),
+            new FabricSkipRestoreOperationException("FabricSkipRestoreOperationException"),
+            new FabricInsufficientMaxLoadCapacityException("FabricInsufficientMaxLoadCapacityException"),
         };
 
         /// <summary>

--- a/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/V2/ExceptionConvertors/SystemExceptionConvertorTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Remoting.Tests/V2/ExceptionConvertors/SystemExceptionConvertorTest.cs
@@ -104,6 +104,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Tests.V2.ExceptionConvertors
             new AbandonedMutexException("AbandonedMutexException"),
             new SemaphoreFullException("SemaphoreFullException"),
             new SynchronizationLockException("SynchronizationLockException"),
+            new TaskCanceledException("TaskCanceledException"),
             new ThreadInterruptedException("ThreadInterruptedException"),
             new ThreadStateException("ThreadStateException"),
             new TimeoutException("TimeoutException"),

--- a/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceNameFormatTests.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Services.Tests/ServiceNameFormatTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ServiceFabric.Services.Tests
     using Xunit;
 
     /// <summary>
-    /// Test class for ServiceNameForamt.
+    /// Test class for ServiceNameFormat.
     /// </summary>
     public class ServiceNameFormatTests
     {


### PR DESCRIPTION
Add following exceptions classes to lists of System and Fabric known exceptions:

* `System.Threading.Tasks.TaskCanceledException`
* `System.Fabric.FabricInsufficientMaxLoadCapacityException`
* `System.Fabric.FabricSkipRestoreOperationException`
* `System.Fabric.FabricBackupNotFoundException`

Bump version (`9.2.4` -> `9.2.5`).

Several minor fixes (proper order of using directives and name spaces, several typos fixed).