### PR TITLE
Reintroduce CLS compliance

### DIFF
--- a/src/FabActUtil/FabActUtil.csproj
+++ b/src/FabActUtil/FabActUtil.csproj
@@ -24,11 +24,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Actors\Microsoft.ServiceFabric.Actors.csproj" />
   </ItemGroup>
-  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Compile Remove="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
+  <ItemGroup>    
+    <Compile Condition="'$(TargetFramework)' == 'netstandard2.0'" Remove="Properties\AssemblyInfo.cs" />
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/FabActUtil/FabActUtil.csproj
+++ b/src/FabActUtil/FabActUtil.csproj
@@ -24,6 +24,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Actors\Microsoft.ServiceFabric.Actors.csproj" />
   </ItemGroup>
+  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/FabActUtil/Properties/AssemblyInfo.cs
+++ b/src/FabActUtil/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting.csproj" />
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />
   </ItemGroup>
+  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Microsoft.ServiceFabric.Actors.KVSToRCMigration.csproj
@@ -25,10 +25,9 @@
     <ProjectReference Include="..\Microsoft.ServiceFabric.Actors\Microsoft.ServiceFabric.Actors.csproj" />
     <ProjectReference Include="..\Microsoft.ServiceFabric.Diagnostics\Microsoft.ServiceFabric.Diagnostics.csproj" />
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services.Remoting\Microsoft.ServiceFabric.Services.Remoting.csproj" />
-    <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />
+    <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />    
   </ItemGroup>
-  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">   
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Actors.Wcf/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Actors.Wcf/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
+++ b/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
@@ -21,6 +21,13 @@
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
+++ b/src/Microsoft.ServiceFabric.Actors/Microsoft.ServiceFabric.Actors.csproj
@@ -21,13 +21,7 @@
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Compile Remove="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Condition="'$(TargetFramework)' == 'netstandard2.0'" Remove="Properties\AssemblyInfo.cs" />
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.ServiceFabric.Actors/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Diagnostics/Microsoft.ServiceFabric.Diagnostics.csproj
+++ b/src/Microsoft.ServiceFabric.Diagnostics/Microsoft.ServiceFabric.Diagnostics.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ServiceFabric" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Diagnostics/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Diagnostics/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
@@ -18,6 +18,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />
   </ItemGroup>
+  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Microsoft.ServiceFabric.Services.Remoting.csproj
@@ -18,12 +18,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Services\Microsoft.ServiceFabric.Services.csproj" />
   </ItemGroup>
-  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Compile Remove="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  
   <ItemGroup>
+    <Compile Condition="'$(TargetFramework)' == 'netstandard2.0'" Remove="Properties\AssemblyInfo.cs" />
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Services.Wcf/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Services.Wcf/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]

--- a/src/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services.csproj
+++ b/src/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services.csproj
@@ -16,6 +16,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ServiceFabric.Diagnostics\Microsoft.ServiceFabric.Diagnostics.csproj" />
   </ItemGroup>
+  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services.csproj
+++ b/src/Microsoft.ServiceFabric.Services/Microsoft.ServiceFabric.Services.csproj
@@ -14,13 +14,10 @@
     <PackageReference Include="Microsoft.ServiceFabric" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.ServiceFabric.Diagnostics\Microsoft.ServiceFabric.Diagnostics.csproj" />
-  </ItemGroup>
-  <!-- Exclude AssemblyInfo.cs for netstandard builds -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <Compile Remove="Properties\AssemblyInfo.cs" />
+    <ProjectReference Include="..\Microsoft.ServiceFabric.Diagnostics\Microsoft.ServiceFabric.Diagnostics.csproj" />    
   </ItemGroup>
   <ItemGroup>
+    <Compile Condition="'$(TargetFramework)' == 'netstandard2.0'" Remove="Properties\AssemblyInfo.cs" />
     <Compile Update="SR.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.ServiceFabric.Services/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.ServiceFabric.Services/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+[assembly: System.CLSCompliant(true)]


### PR DESCRIPTION
**1. Motivation/Goals**

- Goal of this PR is strictly to revert changes where we removed CLS compliance in [this PR](https://github.com/microsoft/service-fabric-services-and-actors-dotnet/pull/408)
-  Intent is to return to the original state for project in this repo regarding CLS compliance, so we are unblocked and can proceed without waiting on approval to remove CLS compliance in WindowsFabric repo.
- This situation is temporary, and long-term goal is to comprehensively remove CLS compliance from this and WindowsFabric repo, so I don't want to invest too much time into making this as clean as possible

**2. Why no CLS AssemblyInfo in netstandard2.0?**
- It was not present in the original separate projects used to build netstandard2.0 assemblies
- We could investigate this further - there seem to be some differences in how CLS works on netstandard/netframework - however this is not the goal of this PR
