### PR TITLE
Cleanup - Remove DotNetCoreClr

### DIFF
--- a/properties/service_fabric_managed_netstandard.props
+++ b/properties/service_fabric_managed_netstandard.props
@@ -2,7 +2,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="service_fabric_managed_common.props" />
   <PropertyGroup>
-    <!-- Define Constants used in code for set standard. -->
-    <DefineConstants>$(DefineConstants);DotNetCoreClr</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/HttpCommunicationClient.cs
+++ b/src/Microsoft.ServiceFabric.Actors.KVSToRCMigration/HttpCommunicationClient.cs
@@ -18,14 +18,13 @@ namespace Microsoft.ServiceFabric.Actors.KVSToRCMigration
         public HttpCommunicationClient(string address)
         {
             this.endpointUri = new Uri(address.EndsWith("/") ? address : $"{address}/");
-#if !DotNetCoreClr
+#if !NET
             var handler = new WinHttpHandler();
             this.httpClient = new HttpClient(handler)
             {
                 BaseAddress = this.endpointUri,
             };
-#endif
-#if DotNetCoreClr
+#else
             this.httpClient = new HttpClient()
             {
                 BaseAddress = this.endpointUri,

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/ActorDataContractSurrogate.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/ActorDataContractSurrogate.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ServiceFabric.Actors.Remoting
     using System.Reflection;
     using System.Runtime.Serialization;
 
-#if DotNetCoreClr
+#if NET
     internal class ActorDataContractSurrogate : ISerializationSurrogateProvider
     {
         public static readonly ISerializationSurrogateProvider Instance = new ActorDataContractSurrogate();

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/ActorLogicalCallContext.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/ActorLogicalCallContext.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Actors.Remoting
 {
-#if DotNetCoreClr
+#if NET
     using System.Threading;
 
     internal static class ActorLogicalCallContext

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/Runtime/ActorServiceRemotingListener.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/Runtime/ActorServiceRemotingListener.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.Runtime
 {
     internal static class ActorServiceRemotingListener
     {
-#if !DotNetCoreClr
+#if !NET
         public static ICommunicationListener CreateActorServiceRemotingListener(
             ActorService actorService)
         {

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V2/ActorRemotingDataContractSerializationProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V2/ActorRemotingDataContractSerializationProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2
             Type remotingRequestType,
             IEnumerable<Type> knownTypes)
         {
-#if DotNetCoreClr
+#if NET
             var serializer =
                 base.CreateRemotingRequestMessageBodyDataContractSerializer(remotingRequestType, knownTypes);
 
@@ -67,7 +67,7 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2
             Type remotingResponseType,
             IEnumerable<Type> knownTypes)
         {
-#if DotNetCoreClr
+#if NET
             var serializer =
                 base.CreateRemotingResponseMessageBodyDataContractSerializer(remotingResponseType, knownTypes);
             serializer.SetSerializationSurrogateProvider(new ActorDataContractSurrogate());

--- a/src/Microsoft.ServiceFabric.Actors/Remoting/V2/ActorRemotingWrappingDataContractSerializationProvider.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Remoting/V2/ActorRemotingWrappingDataContractSerializationProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2
             Type remotingRequestType,
             IEnumerable<Type> knownTypes)
         {
-#if DotNetCoreClr
+#if NET
             var serializer = base.CreateRemotingRequestMessageBodyDataContractSerializer(remotingRequestType, AddDefaultKnownTypes(knownTypes));
 
             serializer.SetSerializationSurrogateProvider(new ActorDataContractSurrogate());
@@ -72,7 +72,7 @@ namespace Microsoft.ServiceFabric.Actors.Remoting.V2
             Type remotingResponseType,
             IEnumerable<Type> knownTypes)
         {
-#if DotNetCoreClr
+#if NET
             var serializer = base.CreateRemotingResponseMessageBodyDataContractSerializer(remotingResponseType, AddDefaultKnownTypes(knownTypes));
 
             serializer.SetSerializationSurrogateProvider(new ActorDataContractSurrogate());

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateProviderHelper.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/ActorStateProviderHelper.cs
@@ -99,7 +99,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                 new DataContractSerializerSettings
                 {
                     MaxItemsInObjectGraph = int.MaxValue,
-#if !DotNetCoreClr
+#if !NET
                     DataContractSurrogate = ActorDataContractSurrogate.Instance,
 #endif
                     KnownTypes = new[]
@@ -107,7 +107,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
                         typeof(ActorReference),
                     },
                 });
-#if DotNetCoreClr
+#if NET
             dataContractSerializer.SetSerializationSurrogateProvider(ActorDataContractSurrogate.Instance);
 #endif
             return dataContractSerializer;
@@ -225,7 +225,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime
             IActorStateProvider stateProvider = new NullActorStateProvider();
             if (actorTypeInfo.StatePersistence.Equals(StatePersistence.Persisted))
             {
-#if DotNetCoreClr
+#if NET
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                 {
                     stateProvider = new KvsActorStateProvider();

--- a/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationReflectionHelper.cs
+++ b/src/Microsoft.ServiceFabric.Actors/Runtime/Migration/MigrationReflectionHelper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.ServiceFabric.Actors.Runtime.Migration
                 {
                     Name = assemblyName,
                     Version = currentAssembly.GetName().Version,
-#if !DotNetCoreClr
+#if !NET
                     CultureInfo = currentAssembly.GetName().CultureInfo,
 #endif
                     ProcessorArchitecture = currentAssembly.GetName().ProcessorArchitecture,

--- a/src/Microsoft.ServiceFabric.Diagnostics/Tracing/ServiceFabricEventSource.cs
+++ b/src/Microsoft.ServiceFabric.Diagnostics/Tracing/ServiceFabricEventSource.cs
@@ -138,7 +138,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
 
                 var hasId = false;
                 int typeFieldIndex = -1;
-#if DotNetCoreClr
+#if NET
                 if (IsLinuxPlatform())
                 {
                     var methodParams = eventMethod.GetParameters().ToList();
@@ -165,7 +165,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
             return new ReadOnlyDictionary<int, TraceEvent>(eventDescriptors);
         }
 
-#if DotNetCoreClr
+#if NET
 
         [NonEvent]
         public void VariantWriteViaNative(int eventId, int argCount, Variant v0 = default, Variant v1 = default, Variant v2 = default, Variant v3 = default, Variant v4 = default, Variant v5 = default, Variant v6 = default, Variant v7 = default, Variant v8 = default)
@@ -292,7 +292,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing
                     }
                 }
             }
-#if DotNetCoreClr
+#if NET
 
             if (IsLinuxPlatform())
             {

--- a/src/Microsoft.ServiceFabric.Diagnostics/Tracing/Writer/TraceEvent.cs
+++ b/src/Microsoft.ServiceFabric.Diagnostics/Tracing/Writer/TraceEvent.cs
@@ -16,7 +16,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing.Writer
         private readonly TraceConfig configMgr;
         private readonly string message;
         private bool filterState;
-#if DotNetCoreClr
+#if NET
         internal bool hasId;
         internal int typeFieldIndex;
 #endif
@@ -37,7 +37,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tracing.Writer
             this.message = message;
             this.UpdateSinkEnabledStatus();
             configMgr.OnFilterUpdate += this.UpdateSinkEnabledStatus;
-#if DotNetCoreClr
+#if NET
             this.hasId = hasId;
             this.typeFieldIndex = typeFieldIndex;
 #endif

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Builder/CodeBuilderContext.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Builder/CodeBuilderContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Builder
         {
             if (this.enableDebugging)
             {
-#if !DotNetCoreClr
+#if !NET
                 this.assemblyBuilder.Save(this.assemblyBuilder.GetName().Name + ".dll");
 #endif
             }

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Builder/CodeBuilderUtils.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Builder/CodeBuilderUtils.cs
@@ -35,7 +35,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Builder
 
         public static AssemblyBuilder CreateAssemblyBuilder(string assemblyName, bool saveOnDisk = false)
         {
-#if !DotNetCoreClr
+#if !NET
             return AssemblyBuilder.DefineDynamicAssembly(
                 new AssemblyName(assemblyName),
                 saveOnDisk ? AssemblyBuilderAccess.RunAndSave : AssemblyBuilderAccess.RunAndCollect);
@@ -51,7 +51,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Builder
             string moduleName,
             bool saveOnDisk = false)
         {
-#if !DotNetCoreClr
+#if !NET
             return saveOnDisk ?
                 assemblyBuilder.DefineDynamicModule(moduleName, string.Concat(moduleName, ".dll"), true)
                 : assemblyBuilder.DefineDynamicModule(moduleName);

--- a/src/Microsoft.ServiceFabric.Services.Remoting/Builder/ProxyBase.cs
+++ b/src/Microsoft.ServiceFabric.Services.Remoting/Builder/ProxyBase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ServiceFabric.Services.Remoting.Builder
             IServiceRemotingRequestMessageBody requestMsgBodyValue,
             CancellationToken cancellationToken);
 
-#if !DotNetCoreClr
+#if !NET
         /// <summary>
         /// Called by the generated proxy class to get the result from the response body.
         /// </summary>

--- a/src/Microsoft.ServiceFabric.Services/Client/ClientRequestTracker.cs
+++ b/src/Microsoft.ServiceFabric.Services/Client/ClientRequestTracker.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.ServiceFabric.Services.Client
 {
- #if DotNetCoreClr
+ #if NET
     using System.Threading;
 
     internal static class ClientRequestTracker

--- a/src/Microsoft.ServiceFabric.Services/LogContext.cs
+++ b/src/Microsoft.ServiceFabric.Services/LogContext.cs
@@ -6,7 +6,7 @@
 namespace Microsoft.ServiceFabric.Services
 {
     using System;
-#if DotNetCoreClr
+#if NET
     using System.Threading;
 
     internal class LogContext

--- a/src/Microsoft.ServiceFabric.Services/TelemetryConstants.cs
+++ b/src/Microsoft.ServiceFabric.Services/TelemetryConstants.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ServiceFabric.Services
 
         static TelemetryConstants()
         {
-#if DotNetCoreClr
+#if NET
             if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 OsType = TelemetryConstants.ClusterOSWindows;

--- a/test/unittests/Microsoft.ServiceFabric.Diagnostics.Tests/ServiceFabricEventSourceTest.cs
+++ b/test/unittests/Microsoft.ServiceFabric.Diagnostics.Tests/ServiceFabricEventSourceTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ServiceFabric.Diagnostics.Tests
 {    
     public abstract class ServiceFabricEventSourceTest
     {
-#if DotNetCoreClr
+#if NET
         public sealed class Class : ServiceFabricEventSourceTest
         {
             [Fact]


### PR DESCRIPTION
Remove obsolete `#if DotNetCoreClr` constant use in favour of `#if NET`