### PR TITLE
Fix ADO build for release_7.1

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,16 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear /> <!--Adding this to avoid NuGet Security Analysis failure -->
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="ServiceFabric_NugetPackages_LocalPath" value="refs" />
   </packageSources>
   <config>
-    <!--
-        Used to specify the default location to expand packages.
-        See: NuGet.exe help install
-        See: NuGet.exe help update
-    -->
     <add key="repositoryPath" value="nuget\restored_packages" />
   </config>
 </configuration>


### PR DESCRIPTION
Make NuGet.config use the default packageSources instead of clearing the inherited sources and defining the nuget.org feed explicitly. This allows GitHub builds to use the public NuGet.org feed, while the official builds use secure internal feeds instead.